### PR TITLE
fix typo: PLCrashAsyncMachoString -> PLCrashAsyncMachOString

### DIFF
--- a/Source/PLCrashAsyncMachOString.c
+++ b/Source/PLCrashAsyncMachOString.c
@@ -26,7 +26,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "PLCrashAsyncMachoString.h"
+#include "PLCrashAsyncMachOString.h"
 
 /**
  * @internal


### PR DESCRIPTION
PLCrashAsyncMachoString cause a compile error