### PR TITLE
Fix to call old signal action

### DIFF
--- a/Source/PLCrashSignalHandler.mm
+++ b/Source/PLCrashSignalHandler.mm
@@ -419,7 +419,7 @@ static PLCrashSignalHandler *sharedHandler;
         .callback = callback,
         .context = context
     };
-    shared_handler_context.callbacks.nasync_prepend(reg);
+    shared_handler_context.callbacks.nasync_append(reg);
     
     return YES;
 }


### PR DESCRIPTION
PLCrashReporter saves the old signal action when registering its own action using sigaction() and the old action will be called by previous_action_callback(). previous_action_callback() is registered in the shared_handler_context.callbacks list and the list is processed by internal_callback_iterator() recursively. previous_action_callback() is implemented to call internal_callback_iterator() recursively by using PLCrashSignalHandlerForward().

What actually happens is that previous_action_callback() is not called, because the head of the shared_handler_context.callbacks list is signal_handler_callback() that is not implemented to call internal_callback_iterator() recursively and therefore the list is not iterated.

Currently signal_handler_callback() is prepended to the shared_handler_context.callbacks list after previous_action_callback() is appended, but I think it should be appended to the end of the list. By doing so, both signal_handler_callback() and previous_action_callback() will be called.