### PR TITLE
Report error message from crash reporter annotations

### DIFF
--- a/Resources/crash_report.proto
+++ b/Resources/crash_report.proto
@@ -284,6 +284,9 @@ message CrashReport {
          * mappings implemented in xnu. As such, when Mach exception data is available, its use should be preferred.
          */
         optional MachException mach_exception = 4;
+
+        /* Message from crash reporter annotations */
+        optional string annotation_message = 5;
     }
 
     /* The signal that triggered the crash */

--- a/Source/PLCrashLogWriter.m
+++ b/Source/PLCrashLogWriter.m
@@ -62,6 +62,24 @@
 
 /**
  * @internal
+ */
+#define CRASHREPORTER_ANNOTATIONS_VERSION 5
+#define CRASHREPORTER_ANNOTATIONS_SECTION "__crash_info"
+#define CRASHREPORTER_ANNOTATIONS_ALIGN __attribute__((aligned(8)))
+
+struct crashreporter_annotations_t {
+  unsigned long version;
+  const char    *message;
+  const char    *signature;
+  const char    *backtrace;
+  const char    *message2;
+  uint64_t      thread;
+  unsigned int  dialog_mode;
+  unsigned int  abort_cause;
+} CRASHREPORTER_ANNOTATIONS_ALIGN;
+
+/**
+ * @internal
  * Protobuf Field IDs, as defined in crashreport.proto
  */
 enum {
@@ -183,6 +201,9 @@ enum {
     
     /** CrashReport.signal.mach_exception */
     PLCRASH_PROTO_SIGNAL_MACH_EXCEPTION_ID = 4,
+
+    /** CrashReport.signal.annotation_message */
+    PLCRASH_PROTO_SIGNAL_ANNOTATION_MESSAGE_ID = 5,
     
     
     /** CrashReport.signal.mach_exception.type */
@@ -1111,7 +1132,7 @@ static size_t plcrash_writer_write_mach_signal (plcrash_async_file_t *file, plcr
  * @param file Output file
  * @param siginfo The signal information
  */
-static size_t plcrash_writer_write_signal (plcrash_async_file_t *file, plcrash_log_signal_info_t *siginfo) {
+static size_t plcrash_writer_write_signal (plcrash_async_file_t *file, plcrash_log_signal_info_t *siginfo, struct crashreporter_annotations_t *annotatiions) {
     size_t rv = 0;
     
     /* BSD signal info is always required in the current report format; this restriction will be lifted
@@ -1154,6 +1175,11 @@ static size_t plcrash_writer_write_signal (plcrash_async_file_t *file, plcrash_l
         /* Write message */
         rv += plcrash_writer_pack(file, PLCRASH_PROTO_SIGNAL_MACH_EXCEPTION_ID, PLPROTOBUF_C_TYPE_MESSAGE, &size);
         rv += plcrash_writer_write_mach_signal(file, siginfo->mach_info);
+    }
+
+    /* Message from crash reporter annotations */
+    if (annotatiions != NULL && annotatiions->message != NULL) {
+        rv += plcrash_writer_pack(file, PLCRASH_PROTO_SIGNAL_ANNOTATION_MESSAGE_ID, PLPROTOBUF_C_TYPE_STRING, annotatiions->message);
     }
 
     return rv;
@@ -1358,6 +1384,18 @@ plcrash_error_t plcrash_log_writer_write (plcrash_log_writer_t *writer,
         plcrash_writer_write_binary_image(file, &image->macho_image);
     }
 
+    /* Try to read crash reporter annotations */
+    struct crashreporter_annotations_t *annotations = NULL;
+    image = plcrash_async_image_containing_address(image_list, siginfo->bsd_info->address);
+    if (image != NULL)
+    {
+        plcrash_async_mobject_t mobj;
+        err = plcrash_async_macho_map_section(&image->macho_image, "__DATA", CRASHREPORTER_ANNOTATIONS_SECTION, &mobj);
+        if (err == PLCRASH_ESUCCESS) {
+            annotations = (struct crashreporter_annotations_t *)(mobj.address + mobj.vm_slide);
+        }
+    }
+
     plcrash_async_image_list_set_reading(image_list, false);
 
     /* Exception */
@@ -1375,9 +1413,9 @@ plcrash_error_t plcrash_log_writer_write (plcrash_log_writer_t *writer,
         uint32_t size;
         
         /* Calculate the message size */
-        size = plcrash_writer_write_signal(NULL, siginfo);
+        size = plcrash_writer_write_signal(NULL, siginfo, annotations);
         plcrash_writer_pack(file, PLCRASH_PROTO_SIGNAL_ID, PLPROTOBUF_C_TYPE_MESSAGE, &size);
-        plcrash_writer_write_signal(file, siginfo);
+        plcrash_writer_write_signal(file, siginfo, annotations);
     }
     
     plcrash_async_symbol_cache_free(&findContext);

--- a/Source/PLCrashLogWriter.m
+++ b/Source/PLCrashLogWriter.m
@@ -62,6 +62,7 @@
 
 /**
  * @internal
+ * See https://github.com/apple/swift/blob/master/include/swift/Runtime/Debug.h
  */
 #define CRASHREPORTER_ANNOTATIONS_VERSION 5
 #define CRASHREPORTER_ANNOTATIONS_SECTION "__crash_info"
@@ -1132,7 +1133,7 @@ static size_t plcrash_writer_write_mach_signal (plcrash_async_file_t *file, plcr
  * @param file Output file
  * @param siginfo The signal information
  */
-static size_t plcrash_writer_write_signal (plcrash_async_file_t *file, plcrash_log_signal_info_t *siginfo, struct crashreporter_annotations_t *annotatiions) {
+static size_t plcrash_writer_write_signal (plcrash_async_file_t *file, plcrash_log_signal_info_t *siginfo, struct crashreporter_annotations_t *annotations) {
     size_t rv = 0;
     
     /* BSD signal info is always required in the current report format; this restriction will be lifted
@@ -1178,8 +1179,8 @@ static size_t plcrash_writer_write_signal (plcrash_async_file_t *file, plcrash_l
     }
 
     /* Message from crash reporter annotations */
-    if (annotatiions != NULL && annotatiions->message != NULL) {
-        rv += plcrash_writer_pack(file, PLCRASH_PROTO_SIGNAL_ANNOTATION_MESSAGE_ID, PLPROTOBUF_C_TYPE_STRING, annotatiions->message);
+    if (annotations != NULL && annotations->message != NULL) {
+        rv += plcrash_writer_pack(file, PLCRASH_PROTO_SIGNAL_ANNOTATION_MESSAGE_ID, PLPROTOBUF_C_TYPE_STRING, annotations->message);
     }
 
     return rv;
@@ -1387,8 +1388,7 @@ plcrash_error_t plcrash_log_writer_write (plcrash_log_writer_t *writer,
     /* Try to read crash reporter annotations */
     struct crashreporter_annotations_t *annotations = NULL;
     image = plcrash_async_image_containing_address(image_list, siginfo->bsd_info->address);
-    if (image != NULL)
-    {
+    if (image != NULL) {
         plcrash_async_mobject_t mobj;
         err = plcrash_async_macho_map_section(&image->macho_image, "__DATA", CRASHREPORTER_ANNOTATIONS_SECTION, &mobj);
         if (err == PLCRASH_ESUCCESS) {

--- a/Source/PLCrashReport.m
+++ b/Source/PLCrashReport.m
@@ -804,8 +804,12 @@ error:
     /* Done */
     NSString *name = [NSString stringWithUTF8String: signalInfo->name];
     NSString *code = [NSString stringWithUTF8String: signalInfo->code];
+    NSString *annotation_message = signalInfo->annotation_message ? [NSString stringWithUTF8String: signalInfo->annotation_message] : nil;
     
-    return [[[PLCrashReportSignalInfo alloc] initWithSignalName: name code: code address: signalInfo->address] autorelease];
+    return [[[PLCrashReportSignalInfo alloc] initWithSignalName: name
+                                                           code: code
+                                                        address: signalInfo->address
+                                              annotationMessage: annotation_message] autorelease];
 }
 
 /**

--- a/Source/PLCrashReportSignalInfo.h
+++ b/Source/PLCrashReportSignalInfo.h
@@ -38,9 +38,15 @@
 
     /** Fauling instruction or address */
     uint64_t _address;
+
+    /** Message from crash reporter annotations */
+    NSString *_annotationMessage;
 }
 
-- (id) initWithSignalName: (NSString *) name code: (NSString *) code address: (uint64_t) address;
+- (id) initWithSignalName: (NSString *) name
+                     code: (NSString *) code
+                  address: (uint64_t) address
+        annotationMessage: (NSString *) annotationMessage;
 
 /**
  * The signal name.
@@ -56,5 +62,10 @@
  * The faulting instruction or address.
  */
 @property(nonatomic, readonly) uint64_t address;
+
+/**
+ * Message from crash reporter annotations.
+ */
+@property(nonatomic, readonly) NSString *annotationMessage;
 
 @end

--- a/Source/PLCrashReportSignalInfo.m
+++ b/Source/PLCrashReportSignalInfo.m
@@ -37,13 +37,17 @@
 /**
  * Initialize with the given signal name and reason.
  */
-- (id) initWithSignalName: (NSString *) name code: (NSString *) code address: (uint64_t) address {
+- (id) initWithSignalName: (NSString *) name
+                     code: (NSString *) code
+                  address: (uint64_t) address
+        annotationMessage: (NSString *) annotationMessage {
     if ((self = [super init]) == nil)
         return nil;
     
     _name = [name retain];
     _code = [code retain];
     _address = address;
+    _annotationMessage = [annotationMessage retain];
     
     return self;
 }
@@ -51,11 +55,13 @@
 - (void) dealloc {
     [_name release];
     [_code release];
+    [_annotationMessage release];
     [super dealloc];
 }
 
 @synthesize name = _name;
 @synthesize code = _code;
 @synthesize address = _address;
+@synthesize annotationMessage = _annotationMessage;
 
 @end


### PR DESCRIPTION
Report [Application Specific Information](https://developer.apple.com/library/archive/technotes/tn2151/_index.html#//apple_ref/doc/uid/DTS40008184-CH1-APPINFO) from [Apple's crash reporter info](https://opensource.apple.com/source/Libc/Libc-825.26/include/CrashReporterClient.h).