### PR TITLE
Add unit test for handling NSException with nil reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Version 1.4.1 (Under development)
 
-* Fix possible crash `plcrash_log_writer_set_exception` method when NSException instances have a nil reason
+* Fix possible crash `plcrash_log_writer_set_exception` method when `NSException` instances have a `nil` reason.
+
+___
 
 ## Version 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # PLCrashReporter Change Log
 
-## Version 1.4
+## Version 1.4.1 (Under development)
+
+* Fix possible crash `plcrash_log_writer_set_exception` method when NSException instances have a nil reason
+
+## Version 1.4.0
 
 * Support macOS 10.15 and XCode 11 and drop support for macOS 10.6.
 * Add support for tvOS apps.

--- a/Source/PLCrashLogWriterTests.m
+++ b/Source/PLCrashLogWriterTests.m
@@ -294,6 +294,20 @@
     return crashReport;
 }
 
+- (void) testWriteLogWithNilReason {
+    plcrash_log_writer_t writer;
+
+    /* Initialize a writer */
+    STAssertEquals(PLCRASH_ESUCCESS, plcrash_log_writer_init(&writer, @"test.id", @"1.0", @"2.0", PLCRASH_ASYNC_SYMBOL_STRATEGY_ALL, false), @"Initialization failed");
+
+    /* Set an exception without reason */
+    NSException *e = [NSException exceptionWithName:@"Exception without reason"
+                                             reason:nil
+                                           userInfo:nil];
+
+    /* Check that the log entry does not initialize the exception */
+    STAssertNoThrow(plcrash_log_writer_set_exception(&writer, e), "Setting an exception failed");
+}
 
 - (void) testWriteReport {
     plframe_cursor_t cursor;


### PR DESCRIPTION
Fix possible crash 'plcrash_log_writer_set_exception' method when NSException instances have a nil reason.

AB#74114