### PR TITLE
Add podspec

### DIFF
--- a/PLCrashReporter.podspec
+++ b/PLCrashReporter.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |spec|
+  spec.name       = 'PLCrashReporter'
+  spec.version    = '1.4.0'
+  spec.summary    = 'Reliable, open-source crash reporting for iOS, macOS and tvOS.'
+
+  spec.homepage   = 'https://github.com/microsoft/plcrashreporter'
+  spec.license    = { :type => 'MIT', :file => 'LICENSE.txt' }
+  spec.authors    = { 'Plausible Labs Cooperative, Inc.'  => 'contact@plausible.coop',
+                      'Microsoft'                         => 'appcentersdk@microsoft.com' }
+
+  spec.source     = { :http     => "https://github.com/microsoft/plcrashreporter/releases/download/#{spec.version}/PLCrashReporter-#{spec.version}.zip",
+                      :flatten  => true }
+
+  spec.ios.deployment_target    = '8.0'
+  spec.ios.vendored_frameworks  = "iOS Framework/CrashReporter.framework"
+
+  spec.osx.deployment_target    = '10.7'
+  spec.osx.vendored_frameworks  = "Mac OS X Framework/CrashReporter.framework"
+  
+  spec.tvos.deployment_target   = '9.0'
+  spec.tvos.vendored_frameworks = "tvOS Framework/CrashReporter.framework"
+end

--- a/PLCrashReporter.podspec
+++ b/PLCrashReporter.podspec
@@ -5,8 +5,7 @@ Pod::Spec.new do |spec|
 
   spec.homepage   = 'https://github.com/microsoft/plcrashreporter'
   spec.license    = { :type => 'MIT', :file => 'LICENSE.txt' }
-  spec.authors    = { 'Plausible Labs Cooperative, Inc.'  => 'contact@plausible.coop',
-                      'Microsoft'                         => 'appcentersdk@microsoft.com' }
+  spec.authors    = { 'Microsoft' => 'appcentersdk@microsoft.com' }
 
   spec.source     = { :http     => "https://github.com/microsoft/plcrashreporter/releases/download/#{spec.version}/PLCrashReporter-#{spec.version}.zip",
                       :flatten  => true }


### PR DESCRIPTION
```
pod spec lint

 -> PLCrashReporter (1.4.0)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Planning build
    - NOTE  | xcodebuild:  note: Constructing build description
    - NOTE  | xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')
    - NOTE  | xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'Pods-App' from project 'Pods')
    - NOTE  | xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'App' from project 'App')

Analyzed 1 podspec.

PLCrashReporter.podspec passed validation.
```

Fixes #46