### PR TITLE
Setup build and short versions

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -16,10 +16,12 @@
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
In `Xcode 10` the `CURRENT_PROJECT_VERSION` meant `CFBundleShortVersionString`. But in `Xcode 11` it is changed and use for `CFBundleVersion` and  for `CFBundleShortVersionString`
 use `MARKETING_VERSION`. 
In the project in `Xcode 11` the `CFBundleShortVersionString` value was null because the `MARKETING_VERSION` did not exist in `Xcode 10`.

This changes are setting in `CFBundleShortVersionString` and `CFBundleVersion` the same values from `CURRENT_PROJECT_VERSION`.

AB#77612