### PR TITLE
Fix issues with new Objective-C runtime version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Embed required `protoc-c` sources instead of using submodule. No more additional steps on cloning the repo.
 * Store sources generated from `*.proto` files to drop `protobuf-c` compiler requirement for building the library. It's required only for contributors now.
 * Enable generating debug symbols for static libraries. Previously it was included only to macOS framework.
-* Add locating class list in `__DATA_CONST` and `__DATA_DIRTY` segments. The behavior matches Objective-C runtime now.
+* Fix symbolication issues with new Objective-C runtime version.
 * Fix framework targets type issue that prevents use the library as a project dependency (instead of binary distribution) in Xcode 11.
 * Fix implicit casting warnings.
 

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -482,7 +482,6 @@
 		C2BBCDAF2456E0E800F9E820 /* PLCrashSysctlTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C2BBCD832456E03D00F9E820 /* PLCrashSysctlTests.m */; };
 		C2CBA40724586975001B775F /* CrashReporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* CrashReporter.framework */; };
 		C2CBA40824586975001B775F /* CrashReporter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* CrashReporter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		C2DCD87D24657D5E007322C5 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C2DCD87824657CE5007322C5 /* libc++.tbd */; platformFilter = maccatalyst; };
 		C2DCD88124658A63007322C5 /* mach_exc.defs in Sources */ = {isa = PBXBuildFile; fileRef = 0581B520168FDB280098C103 /* mach_exc.defs */; };
 		C2DCD88224658A63007322C5 /* mach_exc.defs in Sources */ = {isa = PBXBuildFile; fileRef = 0581B520168FDB280098C103 /* mach_exc.defs */; platformFilter = maccatalyst; };
 		C2F7F1662451E9BD002BD8BF /* CrashReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 05CD318A0EE93A90000FDE88 /* CrashReporter.m */; };
@@ -1230,7 +1229,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C2DCD87D24657D5E007322C5 /* libc++.tbd in Frameworks */,
 				C2F7F2622451F4CE002BD8BF /* CrashReporter.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/PLCrashAsyncMachOImage.c
+++ b/Source/PLCrashAsyncMachOImage.c
@@ -512,7 +512,7 @@ plcrash_error_t plcrash_async_macho_map_section (plcrash_async_macho_t *image, c
         cursor += sizeof(*cmd_32);
     }
 
-    for (uint32_t i = 0; i < nsects; i++) {        
+    for (uint32_t i = 0; i < nsects; i++) {
         struct section *sect_32 = NULL;
         struct section_64 *sect_64 = NULL;
        
@@ -547,8 +547,8 @@ plcrash_error_t plcrash_async_macho_map_section (plcrash_async_macho_t *image, c
                 sectsize = image->byteorder->swap32(sect_32->size);
             }
             
-            
             /* Perform and return the mapping */
+            // PLCF_DEBUG("%s (%s,%s): 0x%lx - 0x%lx", strrchr(image->name, '/'), segname, sectname, sectaddr, sectsize);
             return plcrash_async_mobject_init(mobj, image->task, sectaddr, sectsize, true);
         }
     }

--- a/Source/PLCrashAsyncMachOImage.h
+++ b/Source/PLCrashAsyncMachOImage.h
@@ -91,6 +91,9 @@ typedef struct plcrash_async_macho {
     const plcrash_async_byteorder_t *byteorder;
 } plcrash_async_macho_t;
 
+// Use only filename in debug logging because PLCF_DEBUG has length limit.
+#define PLCF_DEBUG_IMAGE_NAME(image) (strrchr(image->name, '/') + 1)
+
 /**
  * @internal
  *

--- a/Source/PLCrashAsyncObjCSection.h
+++ b/Source/PLCrashAsyncObjCSection.h
@@ -111,7 +111,6 @@ typedef struct plcrash_async_objc_cache {
 
 plcrash_error_t plcrash_async_objc_cache_init (plcrash_async_objc_cache_t *context);
 void plcrash_async_objc_cache_free (plcrash_async_objc_cache_t *context);
-pl_vm_address_t plcrash_async_objc_isa_pointer (pl_vm_address_t isa);
 
 /**
  * A callback to invoke when an Objective-C method is found.

--- a/Source/PLCrashAsyncObjCSection.h
+++ b/Source/PLCrashAsyncObjCSection.h
@@ -86,6 +86,12 @@ typedef struct plcrash_async_objc_cache {
     
     /** A memory object for the __objc_data section. */
     plcrash_async_mobject_t objcDataMobj;
+
+    /** Whether the objcData object is initialized. */
+    bool dataMobjInitialized;
+
+    /** A memory object for the __data section. */
+    plcrash_async_mobject_t dataMobj;
     
     /** The size of the class cache, in entries. */
     size_t classCacheSize;

--- a/Source/PLCrashAsyncObjCSection.h
+++ b/Source/PLCrashAsyncObjCSection.h
@@ -68,7 +68,13 @@ typedef struct plcrash_async_objc_cache {
     
     /** A memory object for the __objc_const section. */
     plcrash_async_mobject_t objcConstMobj;
-    
+
+    /** Whether the objcConstAx object is initialized. */
+    bool objcConstAxMobjInitialized;
+
+    /** A memory object for the __objc_const_ax section. */
+    plcrash_async_mobject_t objcConstAxMobj;
+
     /** Whether the class memory object is initialized. */
     bool classMobjInitialized;
     
@@ -87,7 +93,7 @@ typedef struct plcrash_async_objc_cache {
     /** A memory object for the __objc_data section. */
     plcrash_async_mobject_t objcDataMobj;
 
-    /** Whether the objcData object is initialized. */
+    /** Whether the data object is initialized. */
     bool dataMobjInitialized;
 
     /** A memory object for the __data section. */

--- a/Source/PLCrashAsyncObjCSection.mm
+++ b/Source/PLCrashAsyncObjCSection.mm
@@ -431,7 +431,7 @@ static plcrash_error_t map_sections (plcrash_async_macho_t *image, plcrash_async
     err = map_data_section(image, &segname, kClassListSectionName, &context->classMobj);
     if (err != PLCRASH_ESUCCESS) {
         if (err != PLCRASH_ENOTFOUND)
-            PLCF_DEBUG("pl_async_macho_map_section(%s, %s, %s, %p) failure %d", image->name, segname, kClassListSectionName, &context->classMobj, err);
+            PLCF_DEBUG("pl_async_macho_map_section(%s, %s, %s, %p) failure %d", PLCF_DEBUG_IMAGE_NAME(image), segname, kClassListSectionName, &context->classMobj, err);
         goto cleanup;
     }
     context->classMobjInitialized = true;
@@ -440,7 +440,7 @@ static plcrash_error_t map_sections (plcrash_async_macho_t *image, plcrash_async
     err = map_data_section(image, &segname, kCategoryListSectionName, &context->catMobj);
     if (err != PLCRASH_ESUCCESS) {
         if (err != PLCRASH_ENOTFOUND)
-            PLCF_DEBUG("pl_async_macho_map_section(%s, %s, %s, %p) failure %d", image->name, segname, kCategoryListSectionName, &context->catMobj, err);
+            PLCF_DEBUG("pl_async_macho_map_section(%s, %s, %s, %p) failure %d", PLCF_DEBUG_IMAGE_NAME(image), segname, kCategoryListSectionName, &context->catMobj, err);
         goto cleanup;
     }
     context->catMobjInitialized = true;
@@ -449,7 +449,7 @@ static plcrash_error_t map_sections (plcrash_async_macho_t *image, plcrash_async
     err = plcrash_async_macho_map_section(image, kDataSegmentName, kObjCDataSectionName, &context->objcDataMobj);
     if (err != PLCRASH_ESUCCESS) {
         /* If the class list was found, the data section must also be found. */
-        PLCF_DEBUG("pl_async_macho_map_section(%s, %s, %s, %p) failure %d", image->name, kDataSegmentName, kObjCDataSectionName, &context->objcDataMobj, err);
+        PLCF_DEBUG("pl_async_macho_map_section(%s, %s, %s, %p) failure %d", PLCF_DEBUG_IMAGE_NAME(image), kDataSegmentName, kObjCDataSectionName, &context->objcDataMobj, err);
         goto cleanup;
     }
     context->objcDataMobjInitialized = true;
@@ -984,7 +984,7 @@ static plcrash_error_t pl_async_objc_parse_from_data_section (plcrash_async_mach
     if (err != PLCRASH_ESUCCESS) {
         /* Don't log an error if ObjC data was simply not found */
         if (err != PLCRASH_ENOTFOUND)
-            PLCF_DEBUG("Unable to map relevant sections in %s for ObjC2 class parsing, error %d", image->name, err);
+            PLCF_DEBUG("Unable to map relevant sections in %s for ObjC2 class parsing, error %d", PLCF_DEBUG_IMAGE_NAME(image), err);
         return err;
     }
     
@@ -1231,7 +1231,7 @@ plcrash_error_t plcrash_async_objc_find_method (plcrash_async_macho_t *image, pl
     if (err != PLCRASH_ESUCCESS) {
         /* Don't log an error if ObjC data was simply not found */
         if (err != PLCRASH_ENOTFOUND)
-            PLCF_DEBUG("pl_async_objc_parse of %p (%s) failure %d", image, strrchr(image->name, '/') + 1, err);
+            PLCF_DEBUG("pl_async_objc_parse of %p (%s) failure %d", image, PLCF_DEBUG_IMAGE_NAME(image), err);
         return err;
     }
     

--- a/Source/PLCrashAsyncObjCSection.mm
+++ b/Source/PLCrashAsyncObjCSection.mm
@@ -439,6 +439,8 @@ static plcrash_error_t map_sections (plcrash_async_macho_t *image, plcrash_async
 
     /* Map in the __objc_const_ax section. */
     err = plcrash_async_macho_map_section(image, kDataSegmentName, kObjCConstAxSectionName, &context->objcConstAxMobj);
+    if (err != PLCRASH_ESUCCESS && err != PLCRASH_ENOTFOUND)
+        PLCF_DEBUG("pl_async_macho_map_section(%s, %s, %s, %p) failure %d", PLCF_DEBUG_IMAGE_NAME(image), kDataSegmentName, kObjCConstAxSectionName, &context->objcConstAxMobj, err);
     context->objcConstAxMobjInitialized = err == PLCRASH_ESUCCESS;
     
     /* Map in the class list section. */
@@ -470,6 +472,8 @@ static plcrash_error_t map_sections (plcrash_async_macho_t *image, plcrash_async
 
     /* Map in the __data section. */
     err = plcrash_async_macho_map_section(image, kDataSegmentName, kDataSectionName, &context->dataMobj);
+    if (err != PLCRASH_ESUCCESS && err != PLCRASH_ENOTFOUND)
+        PLCF_DEBUG("pl_async_macho_map_section(%s, %s, %s, %p) failure %d", PLCF_DEBUG_IMAGE_NAME(image), kDataSegmentName, kDataSectionName, &context->dataMobj, err);
     context->dataMobjInitialized = err == PLCRASH_ESUCCESS;
     
     /* Only after all mappings succeed do we set the image. If any failed, the image won't be set,

--- a/Source/PLCrashAsyncSymbolication.c
+++ b/Source/PLCrashAsyncSymbolication.c
@@ -108,7 +108,7 @@ plcrash_error_t plcrash_async_find_symbol (plcrash_async_macho_t *image,
         objcErr = plcrash_async_objc_find_method(image, &cache->objc_cache, pc, objc_symbol_callback, &lookup_ctx);
 
     if (machoErr != PLCRASH_ESUCCESS && objcErr != PLCRASH_ESUCCESS) {
-        PLCF_DEBUG("Could not find symbol for PC %" PRIx64 " image %p", (uint64_t) pc, image);
+        PLCF_DEBUG("Could not find symbol for PC 0x%" PRIx64 " image %p (%s)", (uint64_t) pc, image, PLCF_DEBUG_IMAGE_NAME(image));
         PLCF_DEBUG("pl_async_macho_find_symbol error %d, pl_async_objc_find_method error %d", machoErr, objcErr);
         return machoErr;
     }

--- a/Source/PLCrashAsyncSymbolication.c
+++ b/Source/PLCrashAsyncSymbolication.c
@@ -108,15 +108,14 @@ plcrash_error_t plcrash_async_find_symbol (plcrash_async_macho_t *image,
         objcErr = plcrash_async_objc_find_method(image, &cache->objc_cache, pc, objc_symbol_callback, &lookup_ctx);
 
     if (machoErr != PLCRASH_ESUCCESS && objcErr != PLCRASH_ESUCCESS) {
-        PLCF_DEBUG("Could not find symbol for PC 0x%" PRIx64 " image %p (%s)", (uint64_t) pc, image, PLCF_DEBUG_IMAGE_NAME(image));
-        PLCF_DEBUG("pl_async_macho_find_symbol error %d, pl_async_objc_find_method error %d", machoErr, objcErr);
-        return machoErr;
+        PLCF_DEBUG("Could not find symbol for pc 0x%" PRIx64 " in %s", (uint64_t) pc, PLCF_DEBUG_IMAGE_NAME(image));
+        return PLCRASH_ENOTFOUND;
     }
 
     /* Even if a symbol was found above, our callbacks could have errored out, in which case they would have
      * logged a debug message, not set 'found' */
     if (!lookup_ctx.found) {
-        PLCF_DEBUG("Unexpected error occured in symbol lookup callbacks for PC %" PRIx64 "image %p; returning error", (uint64_t) pc, image);
+        PLCF_DEBUG("Unexpected error occured in symbol lookup callbacks for pc %" PRIx64 " in %s", (uint64_t) pc, PLCF_DEBUG_IMAGE_NAME(image));
         return PLCRASH_EINTERNAL;
     }
 

--- a/Source/PLCrashFrameCompactUnwind.c
+++ b/Source/PLCrashFrameCompactUnwind.c
@@ -59,6 +59,9 @@ plframe_error_t plframe_cursor_read_compact_unwind (task_t task,
         return PLFRAME_EBADFRAME;
     }
     plcrash_greg_t pc = plcrash_async_thread_state_get_reg(&current_frame->thread_state, PLCRASH_REG_IP);
+    if (pc == 0) {
+        return PLFRAME_ENOTSUP;
+    }
     
     /* Find the corresponding image */
     plcrash_async_image_list_set_reading(image_list, true);

--- a/Source/PLCrashFrameDWARFUnwind.cpp
+++ b/Source/PLCrashFrameDWARFUnwind.cpp
@@ -224,6 +224,9 @@ plframe_error_t plframe_cursor_read_dwarf_unwind (task_t task,
         return PLFRAME_EBADFRAME;
     }
     plcrash_greg_t pc = plcrash_async_thread_state_get_reg(&current_frame->thread_state, PLCRASH_REG_IP);
+    if (pc == 0) {
+        return PLFRAME_ENOTSUP;
+    }
 
     /*
      * Mark the list as being read; this prevents any deallocation of our borrowed reference to a plcrash_async_image_t,

--- a/Source/PLCrashFrameDWARFUnwind.cpp
+++ b/Source/PLCrashFrameDWARFUnwind.cpp
@@ -126,9 +126,9 @@ static plframe_error_t plframe_cursor_read_dwarf_unwind_int (task_t task,
     /* Find the FDE (if any) */
     {
         err = reader.find_fde(0x0 /* offset hint */, pc, &fde_info);
-        
         if (err != PLCRASH_ESUCCESS) {
-            PLCF_DEBUG("Failed to find FDE the current frame pc 0x%" PRIx64 " in %s: %d", (uint64_t) pc, PLCF_DEBUG_IMAGE_NAME(image), err);
+            if (err != PLCRASH_ENOTFOUND)
+                PLCF_DEBUG("Failed to find FDE the current frame pc 0x%" PRIx64 " in %s: %d", (uint64_t) pc, PLCF_DEBUG_IMAGE_NAME(image), err);
             result = PLFRAME_ENOTSUP;
             goto cleanup;
         }

--- a/Source/PLCrashFrameDWARFUnwind.cpp
+++ b/Source/PLCrashFrameDWARFUnwind.cpp
@@ -118,7 +118,7 @@ static plframe_error_t plframe_cursor_read_dwarf_unwind_int (task_t task,
     
     /* Initialize the reader. */
     if ((err = reader.init(dwarf_section, image->byteorder, image->m64, is_debug_frame)) != PLCRASH_ESUCCESS) {
-        PLCF_DEBUG("Could not initialize a %s DWARF parser for the current frame pc 0x%" PRIx64 " in %s: %d", (is_debug_frame ? "debug_frame" : "eh_frame"), (uint64_t) pc, strrchr(image->name, '/') + 1, err);
+        PLCF_DEBUG("Could not initialize a %s DWARF parser for the current frame pc 0x%" PRIx64 " in %s: %d", (is_debug_frame ? "debug_frame" : "eh_frame"), (uint64_t) pc, PLCF_DEBUG_IMAGE_NAME(image), err);
         result = PLFRAME_EINVAL;
         goto cleanup;
     }
@@ -128,7 +128,7 @@ static plframe_error_t plframe_cursor_read_dwarf_unwind_int (task_t task,
         err = reader.find_fde(0x0 /* offset hint */, pc, &fde_info);
         
         if (err != PLCRASH_ESUCCESS) {
-            PLCF_DEBUG("Failed to find FDE the current frame pc 0x%" PRIx64 " in %s: %d", (uint64_t) pc, strrchr(image->name, '/') + 1, err);
+            PLCF_DEBUG("Failed to find FDE the current frame pc 0x%" PRIx64 " in %s: %d", (uint64_t) pc, PLCF_DEBUG_IMAGE_NAME(image), err);
             result = PLFRAME_ENOTSUP;
             goto cleanup;
         }

--- a/Source/PLCrashFrameDWARFUnwind.cpp
+++ b/Source/PLCrashFrameDWARFUnwind.cpp
@@ -118,7 +118,7 @@ static plframe_error_t plframe_cursor_read_dwarf_unwind_int (task_t task,
     
     /* Initialize the reader. */
     if ((err = reader.init(dwarf_section, image->byteorder, image->m64, is_debug_frame)) != PLCRASH_ESUCCESS) {
-        PLCF_DEBUG("Could not initialize a %s DWARF parser for the current frame pc: 0x%" PRIx64 ": %d", (is_debug_frame ? "debug_frame" : "eh_frame"), (uint64_t) pc, err);
+        PLCF_DEBUG("Could not initialize a %s DWARF parser for the current frame pc 0x%" PRIx64 " in %s: %d", (is_debug_frame ? "debug_frame" : "eh_frame"), (uint64_t) pc, strrchr(image->name, '/') + 1, err);
         result = PLFRAME_EINVAL;
         goto cleanup;
     }
@@ -128,7 +128,7 @@ static plframe_error_t plframe_cursor_read_dwarf_unwind_int (task_t task,
         err = reader.find_fde(0x0 /* offset hint */, pc, &fde_info);
         
         if (err != PLCRASH_ESUCCESS) {
-            PLCF_DEBUG("Failed to find FDE the current frame pc: 0x%" PRIx64 ": %d", (uint64_t) pc, err);
+            PLCF_DEBUG("Failed to find FDE the current frame pc 0x%" PRIx64 " in %s: %d", (uint64_t) pc, strrchr(image->name, '/') + 1, err);
             result = PLFRAME_ENOTSUP;
             goto cleanup;
         }

--- a/Source/PLCrashNamespace.h
+++ b/Source/PLCrashNamespace.h
@@ -204,7 +204,6 @@
 #define plcrash_async_objc_cache_free PLNS(plcrash_async_objc_cache_free)
 #define plcrash_async_objc_cache_init PLNS(plcrash_async_objc_cache_init)
 #define plcrash_async_objc_find_method PLNS(plcrash_async_objc_find_method)
-#define plcrash_async_objc_isa_pointer PLNS(plcrash_async_objc_isa_pointer)
 #define plcrash_async_read_addr PLNS(plcrash_async_read_addr)
 #define plcrash_async_signal_sigcode PLNS(plcrash_async_signal_sigcode)
 #define plcrash_async_signal_signame PLNS(plcrash_async_signal_signame)


### PR DESCRIPTION
[AB#80244](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/80244)

- Logging in some places was improved to actually find what's going on;
- Add parsing `__data` and `__objc_const_ax` sections as fallbacks;
- Adapt for new `ro_or_rw_ext` tagged pointer in `class_rw_t`;
- Add fail-fast checks for `null` value in `pc` register;