### PR TITLE
Use memory mapping option when reading a crash report file from the disk

### DIFF
--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -746,7 +746,9 @@ static plcrash_error_t plcr_live_report_callback (plcrash_async_thread_state_t *
         goto cleanup;
     }
 
-    data = [NSData dataWithContentsOfFile: [NSString stringWithUTF8String: path]];
+    data = [NSData dataWithContentsOfFile:[NSString stringWithUTF8String: path]
+                                  options:NSDataReadingMappedAlways | NSDataReadingUncached
+                                    error:outError];
     if (data == nil) {
         /* This should only happen if our data is deleted out from under us */
         plcrash_populate_error(outError, PLCrashReporterErrorUnknown, NSLocalizedString(@"Unable to open live crash report for reading", nil), nil);


### PR DESCRIPTION
When generating many live reports in a short period of time the device could run out of memory even when using autorelease pool. Constructing NSData with memory mapping option will reduce a memory footprint for this case.