### PR TITLE
Improve reliability of writing crash reports in case of memory corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Drop support old versions of Xcode. The minimal version is Xcode 11 now.
 * Support [Mac Catalyst](https://developer.apple.com/mac-catalyst/).
 * Distribute `.xcframework` archive alongside with the other options.
+* Improve reliability of writing crash reports in case of memory corruption.
 * Fix symbolication issues with new Objective-C runtime version.
 
 ___

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Drop support old versions of Xcode. The minimal version is Xcode 11 now.
 * Support [Mac Catalyst](https://developer.apple.com/mac-catalyst/).
 * Distribute `.xcframework` archive alongside with the other options.
-* Improve reliability of writing crash reports in case of memory corruption.
+* Improve reliability of saving crash reports in case of memory corruption.
 * Fix symbolication issues with new Objective-C runtime version.
 
 ___

--- a/Other Sources/Crash Demo/main.m
+++ b/Other Sources/Crash Demo/main.m
@@ -80,8 +80,13 @@ static void save_crash_report (PLCrashReporter *reporter) {
         NSLog(@"Failed to load crash report data: %@", error);
         return;
     }
+    [reporter purgePendingCrashReport];
 
     PLCrashReport *report = [[PLCrashReport alloc] initWithData: data error: &error];
+    if (report == nil) {
+       NSLog(@"Failed to parse crash report: %@", error);
+       return;
+   }
     NSString *text = [PLCrashReportTextFormatter stringValueForCrashReport: report withTextFormat: PLCrashReportTextFormatiOS];
     NSLog(@"%@", text);
 
@@ -89,7 +94,6 @@ static void save_crash_report (PLCrashReporter *reporter) {
     if (![data writeToFile: outputPath atomically: YES]) {
         NSLog(@"Failed to write crash report");
     }
-    
     NSLog(@"Saved crash report to: %@", outputPath);
 }
 

--- a/Source/PLCrashLogWriter.h
+++ b/Source/PLCrashLogWriter.h
@@ -41,6 +41,7 @@ extern "C" {
 #import "PLCrashFrameWalker.h"
     
 #import "PLCrashAsyncSymbolication.h"
+#import "PLCrashLogWriterEncoding.h"
 
 #include <uuid/uuid.h>
 
@@ -77,16 +78,16 @@ typedef struct plcrash_log_writer {
     /** System data */
     struct {
         /** The host OS version. */
-        char *version;
+        PLProtobufCBinaryData version;
 
         /** The host OS build number. This may be NULL. */
-        char *build;
+        PLProtobufCBinaryData build;
     } system_info;
 
     /* Machine data */
     struct {
         /** The host model (may be NULL). */
-        char *model;
+        PLProtobufCBinaryData model;
 
         /** The host CPU type. */
         uint64_t cpu_type;
@@ -104,31 +105,31 @@ typedef struct plcrash_log_writer {
     /** Application data */
     struct {
         /** Application identifier */
-        char *app_identifier;
+        PLProtobufCBinaryData app_identifier;
 
         /** Application version */
-        char *app_version;
+        PLProtobufCBinaryData app_version;
         
         /** Application marketing version (may be null) */
-        char *app_marketing_version;
+        PLProtobufCBinaryData app_marketing_version;
     } application_info;
     
     /** Process data */
     struct {
         /** Process name (may be null) */
-        char *process_name;
+        PLProtobufCBinaryData process_name;
         
         /** Process ID */
         pid_t process_id;
         
         /** Process path (may be null) */
-        char *process_path;
+        PLProtobufCBinaryData process_path;
         
         /** Process start time */
         time_t start_time;
         
         /** Parent process name (may be null) */
-        char *parent_process_name;
+        PLProtobufCBinaryData parent_process_name;
         
         /** Parent process ID */
         pid_t parent_process_id;

--- a/Source/PLCrashLogWriter.m
+++ b/Source/PLCrashLogWriter.m
@@ -357,7 +357,8 @@ plcrash_error_t plcrash_log_writer_init (plcrash_log_writer_t *writer,
             PLCrashProcessInfo *parentInfo = [[PLCrashProcessInfo alloc] initWithProcessID: pinfo.parentProcessID];
             if (parentInfo != nil) {
                 if (parentInfo.processName != nil) {
-                    plprotobuf_cbinary_data_nsstring_init(&writer->process_info.parent_process_name, parentInfo.processName);                }
+                    plprotobuf_cbinary_data_nsstring_init(&writer->process_info.parent_process_name, parentInfo.processName);
+                }
             } else {
                 PLCF_DEBUG("Could not retreive parent process name: %s", strerror(errno));
             }

--- a/Source/PLCrashLogWriter.m
+++ b/Source/PLCrashLogWriter.m
@@ -249,6 +249,22 @@ enum {
     PLCRASH_PROTO_REPORT_INFO_UUID_ID = 2,
 };
 
+static void plprotobuf_cbinary_data_string_init (PLProtobufCBinaryData *data, const char *value) {
+    data->data = (void *)value;
+    data->len = strlen(value);
+}
+
+static void plprotobuf_cbinary_data_nsstring_init (PLProtobufCBinaryData *data, NSString *value) {
+    plprotobuf_cbinary_data_string_init(data, strdup([value UTF8String]));
+}
+
+static void plprotobuf_cbinary_data_free (PLProtobufCBinaryData *data) {
+    if (data != NULL && data->data != NULL) {
+        free(data->data);
+        data->len = 0;
+    }
+}
+
 /**
  * Initialize a new crash log writer instance and issue a memory barrier upon completion. This fetches all necessary
  * environment information.
@@ -294,10 +310,10 @@ plcrash_error_t plcrash_log_writer_init (plcrash_log_writer_t *writer,
 
     /* Fetch the application information */
     {
-        writer->application_info.app_identifier = strdup([app_identifier UTF8String]);
-        writer->application_info.app_version = strdup([app_version UTF8String]);
+        plprotobuf_cbinary_data_nsstring_init(&writer->application_info.app_identifier, app_identifier);
+        plprotobuf_cbinary_data_nsstring_init(&writer->application_info.app_version, app_version);
         if (app_marketing_version != nil) {
-            writer->application_info.app_marketing_version = strdup([app_marketing_version UTF8String]);
+            plprotobuf_cbinary_data_nsstring_init(&writer->application_info.app_marketing_version, app_marketing_version);
         }
     }
     
@@ -317,19 +333,18 @@ plcrash_error_t plcrash_log_writer_init (plcrash_log_writer_t *writer,
 
             /* Retrieve name and start time. */
             if (pinfo.processName != nil) {
-                writer->process_info.process_name = strdup([pinfo.processName UTF8String]);
+                plprotobuf_cbinary_data_nsstring_init(&writer->process_info.process_name, pinfo.processName);
             }
             writer->process_info.start_time = pinfo.startTime.tv_sec;
 
             /* Retrieve path */
-            char *process_path = NULL;
             uint32_t process_path_len = 0;
-
             _NSGetExecutablePath(NULL, &process_path_len);
             if (process_path_len > 0) {
-                process_path = malloc(process_path_len);
+                char *process_path = malloc(process_path_len);
                 _NSGetExecutablePath(process_path, &process_path_len);
-                writer->process_info.process_path = process_path;
+                writer->process_info.process_path.data = process_path;
+                writer->process_info.process_path.len = process_path_len;
             }
         }
 
@@ -342,8 +357,7 @@ plcrash_error_t plcrash_log_writer_init (plcrash_log_writer_t *writer,
             PLCrashProcessInfo *parentInfo = [[PLCrashProcessInfo alloc] initWithProcessID: pinfo.parentProcessID];
             if (parentInfo != nil) {
                 if (parentInfo.processName != nil) {
-                    writer->process_info.parent_process_name = strdup([parentInfo.processName UTF8String]);
-                }
+                    plprotobuf_cbinary_data_nsstring_init(&writer->process_info.parent_process_name, parentInfo.processName);                }
             } else {
                 PLCF_DEBUG("Could not retreive parent process name: %s", strerror(errno));
             }
@@ -356,14 +370,15 @@ plcrash_error_t plcrash_log_writer_init (plcrash_log_writer_t *writer,
         /* Model */
 #if TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST
         /* On iOS, we want hw.machine (e.g. hw.machine = iPad2,1; hw.model = K93AP) */
-        writer->machine_info.model = plcrash_sysctl_string("hw.machine");
+        char *model = plcrash_sysctl_string("hw.machine");
 #else
         /* On Mac OS X, we want hw.model (e.g. hw.machine = x86_64; hw.model = Macmini5,3) */
-        writer->machine_info.model = plcrash_sysctl_string("hw.model");
+        char *model = plcrash_sysctl_string("hw.model");
 #endif
-        if (writer->machine_info.model == NULL) {
+        if (model == NULL) {
             PLCF_DEBUG("Could not retrive hw.model: %s", strerror(errno));
         }
+        plprotobuf_cbinary_data_string_init(&writer->machine_info.model, model);
         
         /* CPU */
         {
@@ -419,10 +434,11 @@ plcrash_error_t plcrash_log_writer_init (plcrash_log_writer_t *writer,
     }
 
     /* Fetch the OS information */    
-    writer->system_info.build = plcrash_sysctl_string("kern.osversion");
-    if (writer->system_info.build == NULL) {
+    char *build = plcrash_sysctl_string("kern.osversion");
+    if (build == NULL) {
         PLCF_DEBUG("Could not retrive kern.osversion: %s", strerror(errno));
     }
+    plprotobuf_cbinary_data_string_init(&writer->system_info.build, build);
 
 #if TARGET_OS_IPHONE
     /* iOS, tvOS and Mac Catalyst */
@@ -433,8 +449,7 @@ plcrash_error_t plcrash_log_writer_init (plcrash_log_writer_t *writer,
         if (systemVersion.patchVersion > 0) {
             systemVersionString = [systemVersionString stringByAppendingFormat:@".%ld", (long)systemVersion.patchVersion];
         }
-
-        writer->system_info.version = strdup([systemVersionString UTF8String]);
+        plprotobuf_cbinary_data_nsstring_init(&writer->system_info.version, systemVersionString);
     }
 #elif TARGET_OS_MAC
     /* macOS */
@@ -457,7 +472,9 @@ plcrash_error_t plcrash_log_writer_init (plcrash_log_writer_t *writer,
         }
 
         /* Compose the string */
-        asprintf(&writer->system_info.version, "%" PRId32 ".%" PRId32 ".%" PRId32, (int32_t)major, (int32_t)minor, (int32_t)bugfix);
+        char *version;
+        asprintf(&version, "%" PRId32 ".%" PRId32 ".%" PRId32, (int32_t)major, (int32_t)minor, (int32_t)bugfix);
+        plprotobuf_cbinary_data_string_init(&writer->system_info.version, version);
     }
 #else
 #error Unsupported Platform
@@ -518,31 +535,21 @@ plcrash_error_t plcrash_log_writer_close (plcrash_log_writer_t *writer) {
  */
 void plcrash_log_writer_free (plcrash_log_writer_t *writer) {
     /* Free the app info */
-    if (writer->application_info.app_identifier != NULL)
-        free(writer->application_info.app_identifier);
-    if (writer->application_info.app_version != NULL)
-        free(writer->application_info.app_version);
-    if (writer->application_info.app_marketing_version != NULL)
-        free(writer->application_info.app_marketing_version);
+    plprotobuf_cbinary_data_free(&writer->application_info.app_identifier);
+    plprotobuf_cbinary_data_free(&writer->application_info.app_version);
+    plprotobuf_cbinary_data_free(&writer->application_info.app_marketing_version);
 
     /* Free the process info */
-    if (writer->process_info.process_name != NULL) 
-        free(writer->process_info.process_name);
-    if (writer->process_info.process_path != NULL) 
-        free(writer->process_info.process_path);
-    if (writer->process_info.parent_process_name != NULL) 
-        free(writer->process_info.parent_process_name);
+    plprotobuf_cbinary_data_free(&writer->process_info.process_name);
+    plprotobuf_cbinary_data_free(&writer->process_info.process_path);
+    plprotobuf_cbinary_data_free(&writer->process_info.parent_process_name);
     
     /* Free the system info */
-    if (writer->system_info.version != NULL)
-        free(writer->system_info.version);
-    
-    if (writer->system_info.build != NULL)
-        free(writer->system_info.build);
+    plprotobuf_cbinary_data_free(&writer->system_info.version);
+    plprotobuf_cbinary_data_free(&writer->system_info.build);
     
     /* Free the machine info */
-    if (writer->machine_info.model != NULL)
-        free(writer->machine_info.model);
+    plprotobuf_cbinary_data_free(&writer->machine_info.model);
 
     /* Free the exception data */
     if (writer->uncaught_exception.has_exception) {
@@ -574,10 +581,10 @@ static size_t plcrash_writer_write_system_info (plcrash_async_file_t *file, plcr
     rv += plcrash_writer_pack(file, PLCRASH_PROTO_SYSTEM_INFO_OS_ID, PLPROTOBUF_C_TYPE_ENUM, &enumval);
 
     /* OS Version */
-    rv += plcrash_writer_pack(file, PLCRASH_PROTO_SYSTEM_INFO_OS_VERSION_ID, PLPROTOBUF_C_TYPE_STRING, writer->system_info.version);
+    rv += plcrash_writer_pack(file, PLCRASH_PROTO_SYSTEM_INFO_OS_VERSION_ID, PLPROTOBUF_C_TYPE_BYTES, &writer->system_info.version);
     
     /* OS Build */
-    rv += plcrash_writer_pack(file, PLCRASH_PROTO_SYSTEM_INFO_OS_BUILD_ID, PLPROTOBUF_C_TYPE_STRING, writer->system_info.build);
+    rv += plcrash_writer_pack(file, PLCRASH_PROTO_SYSTEM_INFO_OS_BUILD_ID, PLPROTOBUF_C_TYPE_BYTES, &writer->system_info.build);
 
     /* Machine type */
     enumval = PLCrashReportHostArchitecture;
@@ -626,8 +633,8 @@ static size_t plcrash_writer_write_machine_info (plcrash_async_file_t *file, plc
     size_t rv = 0;
     
     /* Model */
-    if (writer->machine_info.model != NULL)
-        rv += plcrash_writer_pack(file, PLCRASH_PROTO_MACHINE_INFO_MODEL_ID, PLPROTOBUF_C_TYPE_STRING, writer->machine_info.model);
+    if (writer->machine_info.model.data != NULL)
+        rv += plcrash_writer_pack(file, PLCRASH_PROTO_MACHINE_INFO_MODEL_ID, PLPROTOBUF_C_TYPE_BYTES, &writer->machine_info.model);
 
     /* Processor */
     {
@@ -660,18 +667,21 @@ static size_t plcrash_writer_write_machine_info (plcrash_async_file_t *file, plc
  * @param app_version Application version
  * @param app_marketing_version Application marketing version
  */
-static size_t plcrash_writer_write_app_info (plcrash_async_file_t *file, const char *app_identifier, const char *app_version, const char *app_marketing_version) {
+static size_t plcrash_writer_write_app_info (plcrash_async_file_t *file,
+                                             PLProtobufCBinaryData *app_identifier,
+                                             PLProtobufCBinaryData *app_version,
+                                             PLProtobufCBinaryData *app_marketing_version) {
     size_t rv = 0;
 
     /* App identifier */
-    rv += plcrash_writer_pack(file, PLCRASH_PROTO_APP_INFO_APP_IDENTIFIER_ID, PLPROTOBUF_C_TYPE_STRING, app_identifier);
+    rv += plcrash_writer_pack(file, PLCRASH_PROTO_APP_INFO_APP_IDENTIFIER_ID, PLPROTOBUF_C_TYPE_BYTES, app_identifier);
     
     /* App version */
-    rv += plcrash_writer_pack(file, PLCRASH_PROTO_APP_INFO_APP_VERSION_ID, PLPROTOBUF_C_TYPE_STRING, app_version);
+    rv += plcrash_writer_pack(file, PLCRASH_PROTO_APP_INFO_APP_VERSION_ID, PLPROTOBUF_C_TYPE_BYTES, app_version);
     
     /* App marketing version */
     if (app_marketing_version != NULL)
-        rv += plcrash_writer_pack(file, PLCRASH_PROTO_APP_INFO_APP_MARKETING_VERSION_ID, PLPROTOBUF_C_TYPE_STRING, app_marketing_version);
+        rv += plcrash_writer_pack(file, PLCRASH_PROTO_APP_INFO_APP_MARKETING_VERSION_ID, PLPROTOBUF_C_TYPE_BYTES, app_marketing_version);
     
     return rv;
 }
@@ -690,9 +700,9 @@ static size_t plcrash_writer_write_app_info (plcrash_async_file_t *file, const c
  * @param native If false, process is running under emulation.
  * @param start_time The start time of the process.
  */
-static size_t plcrash_writer_write_process_info (plcrash_async_file_t *file, const char *process_name,
-                                                 const pid_t process_id, const char *process_path, 
-                                                 const char *parent_process_name, const pid_t parent_process_id,
+static size_t plcrash_writer_write_process_info (plcrash_async_file_t *file, PLProtobufCBinaryData *process_name,
+                                                 const pid_t process_id, PLProtobufCBinaryData *process_path,
+                                                 PLProtobufCBinaryData *parent_process_name, const pid_t parent_process_id,
                                                  bool native, time_t start_time)
 {
     size_t rv = 0;
@@ -711,7 +721,7 @@ static size_t plcrash_writer_write_process_info (plcrash_async_file_t *file, con
 
     /* Process name */
     if (process_name != NULL)
-        rv += plcrash_writer_pack(file, PLCRASH_PROTO_PROCESS_INFO_PROCESS_NAME_ID, PLPROTOBUF_C_TYPE_STRING, process_name);
+        rv += plcrash_writer_pack(file, PLCRASH_PROTO_PROCESS_INFO_PROCESS_NAME_ID, PLPROTOBUF_C_TYPE_BYTES, process_name);
 
     /* Process ID */
     pidval = process_id;
@@ -719,11 +729,11 @@ static size_t plcrash_writer_write_process_info (plcrash_async_file_t *file, con
 
     /* Process path */
     if (process_path != NULL)
-        rv += plcrash_writer_pack(file, PLCRASH_PROTO_PROCESS_INFO_PROCESS_PATH_ID, PLPROTOBUF_C_TYPE_STRING, process_path);
+        rv += plcrash_writer_pack(file, PLCRASH_PROTO_PROCESS_INFO_PROCESS_PATH_ID, PLPROTOBUF_C_TYPE_BYTES, process_path);
     
     /* Parent process name */
     if (parent_process_name != NULL)
-        rv += plcrash_writer_pack(file, PLCRASH_PROTO_PROCESS_INFO_PARENT_PROCESS_NAME_ID, PLPROTOBUF_C_TYPE_STRING, parent_process_name);
+        rv += plcrash_writer_pack(file, PLCRASH_PROTO_PROCESS_INFO_PARENT_PROCESS_NAME_ID, PLPROTOBUF_C_TYPE_BYTES, parent_process_name);
     
 
     /* Parent process ID */
@@ -1293,11 +1303,11 @@ plcrash_error_t plcrash_log_writer_write (plcrash_log_writer_t *writer,
         uint32_t size;
 
         /* Determine size */
-        size = (uint32_t) plcrash_writer_write_app_info(NULL, writer->application_info.app_identifier, writer->application_info.app_version, writer->application_info.app_marketing_version);
+        size = (uint32_t) plcrash_writer_write_app_info(NULL, &writer->application_info.app_identifier, &writer->application_info.app_version, &writer->application_info.app_marketing_version);
         
         /* Write message */
         plcrash_writer_pack(file, PLCRASH_PROTO_APP_INFO_ID, PLPROTOBUF_C_TYPE_MESSAGE, &size);
-        plcrash_writer_write_app_info(file, writer->application_info.app_identifier, writer->application_info.app_version, writer->application_info.app_marketing_version);
+        plcrash_writer_write_app_info(file, &writer->application_info.app_identifier, &writer->application_info.app_version, &writer->application_info.app_marketing_version);
     }
     
     /* Process info */
@@ -1305,15 +1315,15 @@ plcrash_error_t plcrash_log_writer_write (plcrash_log_writer_t *writer,
         uint32_t size;
         
         /* Determine size */
-        size = (uint32_t) plcrash_writer_write_process_info(NULL, writer->process_info.process_name, writer->process_info.process_id,
-                                                 writer->process_info.process_path, writer->process_info.parent_process_name,
+        size = (uint32_t) plcrash_writer_write_process_info(NULL, &writer->process_info.process_name, writer->process_info.process_id,
+                                                 &writer->process_info.process_path, &writer->process_info.parent_process_name,
                                                  writer->process_info.parent_process_id, writer->process_info.native,
                                                  writer->process_info.start_time);
         
         /* Write message */
         plcrash_writer_pack(file, PLCRASH_PROTO_PROCESS_INFO_ID, PLPROTOBUF_C_TYPE_MESSAGE, &size);
-        plcrash_writer_write_process_info(file, writer->process_info.process_name, writer->process_info.process_id, 
-                                          writer->process_info.process_path, writer->process_info.parent_process_name, 
+        plcrash_writer_write_process_info(file, &writer->process_info.process_name, writer->process_info.process_id,
+                                          &writer->process_info.process_path, &writer->process_info.parent_process_name, 
                                           writer->process_info.parent_process_id, writer->process_info.native,
                                           writer->process_info.start_time);
     }

--- a/Tests/PLCrashLogWriterTests.m
+++ b/Tests/PLCrashLogWriterTests.m
@@ -297,7 +297,7 @@
     plcrash_log_writer_t writer;
 
     STAssertEquals(PLCRASH_ESUCCESS, plcrash_log_writer_init(&writer, @"test.id", @"1.0", @"2.0", PLCRASH_ASYNC_SYMBOL_STRATEGY_ALL, false), @"Initialization failed");
-    char *version = writer.system_info.version;
+    char *version = writer.system_info.version.data;
 
     STAssertTrue(version && version[0], @"Device version not saved");
 }


### PR DESCRIPTION
Improve reliability of writing crash reports in case of memory corruption.

[Reproduction](https://github.com/microsoft/appcenter-sdk-apple/blob/0daf878bbb2942261eeb54b7af0722f8c1434a2a/CrashLib/CrashLib/MSCrashCorruptMalloc.m#L26-L33):
```objc
/* Smash the heap, and keep smashing it until we eventually hit something non-writable, or trigger
* a malloc error (e.g., in NSLog). */
uint8_t *memory = malloc(10);
while (true) {
  NSLog(@"Smashing [%p - %p]", memory, memory + PAGE_SIZE);
  memset((void *) trunc_page((vm_address_t) memory), 0xAB, PAGE_SIZE);
  memory += PAGE_SIZE;
}
```

[AB#80436](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/80436)