### PR TITLE
Workaround for SwiftPM on Xcode 11.1 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Distribute `.xcframework` archive alongside with the other options.
 * Improve reliability of saving crash reports in case of memory corruption.
 * Fix symbolication issues with new Objective-C runtime version.
+* Add workaround for SwiftPM on Xcode 11.1 bug (`SWIFT_PACKAGE` is not defined) that prevents library usage on macOS.
 
 ___
 

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
                 .define("PLCR_PRIVATE"),
                 .define("PLCF_RELEASE_BUILD"),
                 .define("PLCRASHREPORTER_PREFIX", to: ""),
+                .define("SWIFT_PACKAGE"), // Should be defined by default, Xcode 11.1 workaround.
                 .headerSearchPath("Dependencies/protobuf-c")
             ],
             linkerSettings: [


### PR DESCRIPTION
Add workaround for SwiftPM on Xcode 11.1 bug (`SWIFT_PACKAGE` is not defined) that prevents library usage on macOS.

[AB#80761](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/80761)