### PR TITLE
Set skip install property for static libraries and frameworks

### DIFF
--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -3498,6 +3498,7 @@
 				"OTHER_CFLAGS[sdk=macosx*]" = "";
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -3522,6 +3523,7 @@
 				"OTHER_CFLAGS[sdk=macosx*]" = "";
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -3884,6 +3886,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -3907,6 +3910,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -3555,6 +3555,7 @@
 				"OTHER_CFLAGS[sdk=macosx*]" = "";
 				PUBLIC_HEADERS_FOLDER_PATH = include;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -3575,6 +3576,7 @@
 				"OTHER_CFLAGS[sdk=macosx*]" = "";
 				PUBLIC_HEADERS_FOLDER_PATH = include;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -3660,6 +3662,7 @@
 				);
 				PUBLIC_HEADERS_FOLDER_PATH = include;
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -3674,6 +3677,7 @@
 				);
 				PUBLIC_HEADERS_FOLDER_PATH = include;
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -3844,6 +3848,7 @@
 				OTHER_CFLAGS = "-fembed-bitcode-marker";
 				PUBLIC_HEADERS_FOLDER_PATH = include;
 				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -3857,6 +3862,7 @@
 				"OTHER_CFLAGS[sdk=appletvos*]" = "-fembed-bitcode";
 				PUBLIC_HEADERS_FOLDER_PATH = include;
 				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This PR changes static libraries and frameworks targets - it sets SKIP_INSTALL property to true.
[Apple documentation
](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW36)
[AB#81393](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/81393)
#102 