### PR TITLE
Fix arm64e reports in some cases

### DIFF
--- a/Source/PLCrashAsyncSignalInfo.c
+++ b/Source/PLCrashAsyncSignalInfo.c
@@ -124,6 +124,7 @@ static struct signal_code signal_codes[] = {
     { SIGBUS,   BUS_OBJERR,     "BUS_OBJERR"  },
 
     /* SIGTRAP */
+    { SIGTRAP,  0,              "#0"          },
     { SIGTRAP,  TRAP_BRKPT,     "TRAP_BRKPT"  },
     { SIGTRAP,  TRAP_TRACE,     "TRAP_TRACE"  },
 

--- a/Source/PLCrashAsyncThread_arm.c
+++ b/Source/PLCrashAsyncThread_arm.c
@@ -59,6 +59,7 @@
 })
 #define THREAD_STATE_GET_FPTR(name, type, ts)  ({ \
     plcrash_greg_t ptr = (plcrash_greg_t) arm_thread_state64_get_ ## name ## _fptr (ts->arm_state. type); \
+    ptr = ptr ? ptr : arm_thread_state64_get_ ## name (ts->arm_state. type); \
     (plcrash_greg_t) ptrauth_strip((void *) ptr, ptrauth_key_function_pointer); \
 })
 
@@ -89,6 +90,7 @@
 })
 #define THREAD_STATE_GET_FPTR(name, type, ts) ({ \
     plcrash_greg_t ptr = (plcrash_greg_t) arm_thread_state64_get_ ## name ## _fptr (ts->arm_state. type); \
+    ptr = ptr ? ptr : arm_thread_state64_get_ ## name (ts->arm_state. type); \
     (ptr & ARM64_PTR_MASK); \
 })
 

--- a/Source/PLCrashAsyncThread_arm.c
+++ b/Source/PLCrashAsyncThread_arm.c
@@ -82,8 +82,6 @@
  * Even if pointer authentication is not available at the compile time, the binary still can be used in an environment with PAC.
  * In this case, we can apply bitmask as a workaround.
  */
-#define ARM64_PTR_MASK 0x0000000FFFFFFFFF
-
 #define THREAD_STATE_GET_PTR(name, type, ts) ({ \
     plcrash_greg_t ptr = arm_thread_state64_get_ ## name (ts->arm_state. type); \
     (ptr & ARM64_PTR_MASK); \

--- a/Source/PLCrashAsyncThread_arm.h
+++ b/Source/PLCrashAsyncThread_arm.h
@@ -33,6 +33,11 @@
 extern "C" {
 #endif
 
+/**
+ * Bitmask to strip pointer authentication (PAC).
+ */
+#define ARM64_PTR_MASK 0x0000000FFFFFFFFF
+
 #if defined(__arm__) || defined(__arm64__)
 
 // Large enough for 64-bit or 32-bit

--- a/Source/PLCrashAsyncThread_current.S
+++ b/Source/PLCrashAsyncThread_current.S
@@ -188,7 +188,7 @@ ret
 
 stp     fp, lr, [sp, #-16]!
 add     fp, sp, 0
-sub     sp, sp, #816 // Size of 340 for context
+sub     sp, sp, #816 // Size of 816 for context
 
 // These assumed offsets are compile-time validated in PLCrashLogWriter_trampoline.m, and are ABI-stable.
 

--- a/Source/PLCrashReport.m
+++ b/Source/PLCrashReport.m
@@ -195,9 +195,6 @@ error:
 - (PLCrashReportBinaryImageInfo *) imageForAddress: (uint64_t) address {
     for (PLCrashReportBinaryImageInfo *imageInfo in self.images) {
         uint64_t normalizedBaseAddress = imageInfo.imageBaseAddress;
-#if __DARWIN_OPAQUE_ARM_THREAD_STATE64
-        normalizedBaseAddress &= 0x0000000fffffffff;
-#endif
         if (normalizedBaseAddress <= address && address < (normalizedBaseAddress + imageInfo.imageSize))
             return imageInfo;
     }

--- a/Source/PLCrashReportTextFormatter.m
+++ b/Source/PLCrashReportTextFormatter.m
@@ -505,16 +505,11 @@ static NSInteger binaryImageSort(id binary1, id binary2, void *context);
     NSString *imageName = @"\?\?\?";
     NSString *symbolString = nil;
 
-    uint64_t normalizedInstructionPointer = frameInfo.instructionPointer;
-#if __DARWIN_OPAQUE_ARM_THREAD_STATE64
-    normalizedInstructionPointer &= 0x0000000fffffffff;
-#endif
-
-    PLCrashReportBinaryImageInfo *imageInfo = [report imageForAddress: normalizedInstructionPointer];
+    PLCrashReportBinaryImageInfo *imageInfo = [report imageForAddress:frameInfo.instructionPointer];
     if (imageInfo != nil) {
         imageName = [imageInfo.imageName lastPathComponent];
         baseAddress = imageInfo.imageBaseAddress;
-        pcOffset = normalizedInstructionPointer - imageInfo.imageBaseAddress;
+        pcOffset = frameInfo.instructionPointer - imageInfo.imageBaseAddress;
     }
 
     /* If symbol info is available, the format used in Apple's reports is Sym + OffsetFromSym. Otherwise,
@@ -540,7 +535,7 @@ static NSInteger binaryImageSort(id binary1, id binary2, void *context);
         }
         
         
-        uint64_t symOffset = normalizedInstructionPointer - frameInfo.symbolInfo.startAddress;
+        uint64_t symOffset = frameInfo.instructionPointer - frameInfo.symbolInfo.startAddress;
         symbolString = [NSString stringWithFormat: @"%@ + %" PRId64, symbolName, symOffset];
     } else {
         symbolString = [NSString stringWithFormat: @"0x%" PRIx64 " + %" PRId64, baseAddress, pcOffset];
@@ -552,7 +547,7 @@ static NSInteger binaryImageSort(id binary1, id binary2, void *context);
     return [NSString stringWithFormat: @"%-4ld%-35S 0x%0*" PRIx64 " %@\n",
             (long) frameIndex,
             (const uint16_t *)[imageName cStringUsingEncoding: NSUTF16StringEncoding],
-            lp64 ? 16 : 8, normalizedInstructionPointer,
+            lp64 ? 16 : 8, frameInfo.instructionPointer,
             symbolString];
 }
 

--- a/Source/PLCrashReportTextFormatter.m
+++ b/Source/PLCrashReportTextFormatter.m
@@ -517,8 +517,7 @@ static NSInteger binaryImageSort(id binary1, id binary2, void *context);
     if (frameInfo.symbolInfo != nil) {
         NSString *symbolName = frameInfo.symbolInfo.symbolName;
 
-        /* Apple strips the _ symbol prefix in their reports. Only OS X makes use of an
-         * underscore symbol prefix by default. */
+        /* Apple strips the _ symbol prefix in their reports. */
         if ([symbolName rangeOfString: @"_"].location == 0 && [symbolName length] > 1) {
             switch (report.systemInfo.operatingSystem) {
                 case PLCrashReportOperatingSystemMacOSX:
@@ -529,7 +528,7 @@ static NSInteger binaryImageSort(id binary1, id binary2, void *context);
                     break;
 
                 default:
-                    NSLog(@"Symbol prefix rules are unknown for this OS!");
+                    NSLog(@"Symbol \"%@\" prefix rules are unknown for this OS!", symbolName);
                     break;
             }
         }

--- a/Source/PLCrashReportTextFormatter.m
+++ b/Source/PLCrashReportTextFormatter.m
@@ -33,6 +33,7 @@
 
 #import "PLCrashReportTextFormatter.h"
 #import "PLCrashCompatConstants.h"
+#import "PLCrashAsync.h"
 
 @interface PLCrashReportTextFormatter (PrivateAPI)
 static NSInteger binaryImageSort(id binary1, id binary2, void *context);
@@ -510,6 +511,8 @@ static NSInteger binaryImageSort(id binary1, id binary2, void *context);
         imageName = [imageInfo.imageName lastPathComponent];
         baseAddress = imageInfo.imageBaseAddress;
         pcOffset = frameInfo.instructionPointer - imageInfo.imageBaseAddress;
+    } else if (frameInfo.instructionPointer) {
+        PLCF_DEBUG("Cannot find image for 0x%" PRIx64, frameInfo.instructionPointer);
     }
 
     /* If symbol info is available, the format used in Apple's reports is Sym + OffsetFromSym. Otherwise,
@@ -528,7 +531,7 @@ static NSInteger binaryImageSort(id binary1, id binary2, void *context);
                     break;
 
                 default:
-                    NSLog(@"Symbol \"%@\" prefix rules are unknown for this OS!", symbolName);
+                    PLCF_DEBUG("Symbol \"%s\" prefix rules are unknown for this OS!", [symbolName UTF8String]);
                     break;
             }
         }


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

- Sometimes, PLCrashReporter cannot find any stack frames on `arm64e` and write just `0x0` to all threads:
    ```
    Thread 0 Crashed:
    0   ???                                 0x0000000000000000 0x0 + 0
    Thread 1:
    0   ???                                 0x0000000000000000 0x0 + 0
    Thread 2:
    0   ???                                 0x0000000000000000 0x0 + 0
    Thread 3:
    0   ???                                 0x0000000000000000 0x0 + 0
    ```
    It was because documented fallback on reading from thread state wasn't applied, see [thread_status.h](https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/arm/thread_status.h)
    > Return pc field of arm_thread_state64_t as a function pointer. May return NULL if a valid function pointer cannot be constructed, the caller should fall back to the arm_thread_state64_get_pc() macro in that case.

- Stripping PAC was incorrectly applied to image base addresses (no effect + won't work in `plcrashutil` if implemented via preprocessor). This mask should not be applied on formatting time at all. So, some part of the changes from https://github.com/microsoft/plcrashreporter/commit/c302c48556d047b46b8f0dbcb7c5ecf01629bb62 and #35 aren't required anymore.

- Added missing signal code for some cases, to avoid
    ```
    [PLCrashReport] plcrash_writer_write_signal:1150: Warning -- unhandled signal sicode (signo=5, code=0). This is a bug.
    ```

- Fix (copy-pasted) comment in reading thread state asm

- Apply mask on parsing reports to correctly handle old ones

## Related PRs or issues

[AB#81394](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/81394)