### PR TITLE
Revert os_unfair_lock usage

### DIFF
--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -3613,6 +3613,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "Tests iOS";
 				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -3625,6 +3626,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "Tests iOS";
 				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;

--- a/Source/PLCrashAsyncLinkedList.hpp
+++ b/Source/PLCrashAsyncLinkedList.hpp
@@ -31,18 +31,8 @@
 
 #include "PLCrashAsync.h"
 #include "PLCrashMacros.h"
+#include "PLCrashCompatConstants.h"
 #include <atomic>
-
-/*
- * OSAtomic* and OSSpinLock are deprecated since macOS 10.12, iOS 10.0 and tvOS 10.0, but suggested replacement
- * for OSSpinLock is missed at runtime on older versions, so we must use it until we support older versions.
- * For modern platforms like Mac Catalyst where we can use the new API, define OSSPINLOCK_USE_INLINED=1 to get
- * inline implementations of the OSSpinLock interfaces in terms of the <os/lock.h> primitives.
- */
-#if TARGET_OS_MACCATALYST
-#define OSSPINLOCK_USE_INLINED 1
-#endif
-#include <libkern/OSAtomic.h>
 
 PLCR_CPP_BEGIN_NS
 
@@ -165,7 +155,7 @@ private:
     void free_list (node *next);
 
     /** The lock used by writers. No lock is required for readers. */
-    OSSpinLock _write_lock;
+    PLCR_COMPAT_LOCK_TYPE _write_lock;
     
     /** The head of the list, or NULL if the list is empty. Must only be used to iterate or delete entries. */
     std::atomic<node *> _head;
@@ -187,7 +177,7 @@ template <typename V> async_list<V>::async_list (void) {
     _tail = NULL;
     _free = NULL;
     _refcount = 0;
-    _write_lock = OS_SPINLOCK_INIT;
+    _write_lock = PLCR_COMPAT_LOCK_INIT;
 }
     
 template <typename V> async_list<V>::~async_list (void) {
@@ -208,7 +198,7 @@ template <typename V> async_list<V>::~async_list (void) {
  */
 template <typename V> void async_list<V>::nasync_prepend (V value) {
     /* Lock the list from other writers. */
-    OSSpinLockLock(&_write_lock); {
+    PLCR_COMPAT_LOCK_LOCK(&_write_lock); {
         /* Construct the new entry, or recycle an existing one. */
         node *new_node;
         if (_free != NULL) {
@@ -257,7 +247,7 @@ template <typename V> void async_list<V>::nasync_prepend (V value) {
                 PLCF_DEBUG("Failed to prepend to image list despite holding lock");
             }
         }
-    } OSSpinLockUnlock(&_write_lock);
+    } PLCR_COMPAT_LOCK_UNLOCK(&_write_lock);
 }
 
 
@@ -271,7 +261,7 @@ template <typename V> void async_list<V>::nasync_prepend (V value) {
 template <typename V> void async_list<V>::nasync_append (V value) {
     
     /* Lock the list from other writers. */
-    OSSpinLockLock(&_write_lock); {
+    PLCR_COMPAT_LOCK_LOCK(&_write_lock); {
         /* Construct the new entry, or recycle an existing one. */
         node *new_node;
         if (_free != NULL) {
@@ -315,7 +305,7 @@ template <typename V> void async_list<V>::nasync_append (V value) {
             new_node->_prev = _tail;
             _tail = new_node;
         }
-    } OSSpinLockUnlock(&_write_lock);
+    } PLCR_COMPAT_LOCK_UNLOCK(&_write_lock);
 }
 
 /**
@@ -347,7 +337,7 @@ template <typename V> void async_list<V>::nasync_remove_first_value (V value) {
  */
 template <typename V> void async_list<V>::nasync_remove_node (node *deleted_node) {
     /* Lock the list from other writers. */
-    OSSpinLockLock(&_write_lock); {
+    PLCR_COMPAT_LOCK_LOCK(&_write_lock); {
         /* Find the record. */
         node *item = _head;
         while (item != NULL) {
@@ -359,7 +349,7 @@ template <typename V> void async_list<V>::nasync_remove_node (node *deleted_node
         
         /* If not found, nothing to do */
         if (item == NULL) {
-            OSSpinLockUnlock(&_write_lock);
+            PLCR_COMPAT_LOCK_UNLOCK(&_write_lock);
             return;
         }
         
@@ -402,7 +392,7 @@ template <typename V> void async_list<V>::nasync_remove_node (node *deleted_node
         } else {
             delete item;
         }
-    } OSSpinLockUnlock(&_write_lock);
+    } PLCR_COMPAT_LOCK_UNLOCK(&_write_lock);
 }
 
 /**

--- a/Source/PLCrashCompatConstants.h
+++ b/Source/PLCrashCompatConstants.h
@@ -64,4 +64,22 @@
 #define UNWIND_ARM64_DWARF_SECTION_OFFSET       0x00FFFFFF
 #endif
 
+/*
+ * OSAtomic* and OSSpinLock are deprecated since macOS 10.12, iOS 10.0 and tvOS 10.0, but suggested replacement
+ * for OSSpinLock is missed at runtime on older versions, so we must use it until we support older versions.
+ */
+#if TARGET_OS_MACCATALYST
+#include <os/lock.h>
+#define PLCR_COMPAT_LOCK_TYPE           os_unfair_lock
+#define PLCR_COMPAT_LOCK_INIT           OS_UNFAIR_LOCK_INIT
+#define PLCR_COMPAT_LOCK_LOCK(lock)     os_unfair_lock_lock(lock)
+#define PLCR_COMPAT_LOCK_UNLOCK(lock)   os_unfair_lock_unlock(lock)
+#else
+#include <libkern/OSAtomic.h>
+#define PLCR_COMPAT_LOCK_TYPE           OSSpinLock
+#define PLCR_COMPAT_LOCK_INIT           OS_SPINLOCK_INIT
+#define PLCR_COMPAT_LOCK_LOCK(lock)     OSSpinLockLock(lock)
+#define PLCR_COMPAT_LOCK_UNLOCK(lock)   OSSpinLockUnlock(lock)
+#endif
+
 #endif /* PLCRASH_COMPAT_CONSTANTS_H */


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

`OSAtomic*` and `OSSpinLock` are deprecated since macOS 10.12, iOS 10.0 and tvOS 10.0, but suggested replacement for OSSpinLock is missed at runtime on older versions, so we must use it until we support older versions.
~For modern platforms like Mac Catalyst where we can use the new API, define `OSSPINLOCK_USE_INLINED=1` to get inline implementations of the `OSSpinLock` interfaces in terms of the `<os/lock.h>` primitives.~

## Related PRs or issues

[AB#81586](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/81586)
#107