### PR TITLE
Fix spinlock deprecation condition

### DIFF
--- a/Source/PLCrashCompatConstants.h
+++ b/Source/PLCrashCompatConstants.h
@@ -68,7 +68,10 @@
  * OSAtomic* and OSSpinLock are deprecated since macOS 10.12, iOS 10.0 and tvOS 10.0, but suggested replacement
  * for OSSpinLock is missed at runtime on older versions, so we must use it until we support older versions.
  */
-#if TARGET_OS_MACCATALYST
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12 || \
+    __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_10_0 || \
+    __TV_OS_VERSION_MIN_REQUIRED >= __TVOS_10_0 || \
+    __WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0
 #include <os/lock.h>
 #define PLCR_COMPAT_LOCK_TYPE           os_unfair_lock
 #define PLCR_COMPAT_LOCK_INIT           OS_UNFAIR_LOCK_INIT


### PR DESCRIPTION
* ~[ ] Has `CHANGELOG.md` been updated?~ I'll summarize all missing lines there separately
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with the sample apps?

## Description

Old condition doesn't cover the cases when PLCR is included as sources and minimal target is higher than this depreciation version.

Fixes `error: 'OSSpinLock' is deprecated: first deprecated in macOS 10.12` compilation error.

## Related PRs or issues

[AB#83058](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/83058)
https://github.com/microsoft/appcenter-sdk-apple/issues/2168/