### PR TITLE
Disable parallel builds for workaround Xcode 12 bug

### DIFF
--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter iOS Framework.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter iOS Framework.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter macOS Framework.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter macOS Framework.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter tvOS Framework.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter tvOS Framework.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash iOS.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash iOS.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash macOS.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash macOS.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash tvOS.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash tvOS.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry


### PR DESCRIPTION
* ~[ ] Has `CHANGELOG.md` been updated?~ I'll summarize all missing lines there separately
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with the sample apps?

## Description

Parallel build in Xcode 12 is broken. Have to disable it as workaround.

Example where the library is used before creating:

```
▸ Compiling PLCrashAsyncCompactUnwindEncoding.c
▸ Compiling PLCrashAsync.c
▸ Compiling CrashReporter.m
▸ Compiling CrashReporterFramework.m
▸ Compiling CrashReporterFramework.m

❌  ld: file not found: /$USER_HOME/Library/Caches/org.carthage.CarthageKit/DerivedData/12.0_12A7209/plcrashreporter/7de33819a0a48e6fc19f28c0808baca4561d50d6/Build/Products/Release-iphonesimulator/libCrashReporter.a



❌  ld: file not found: /$USER_HOME/Library/Caches/org.carthage.CarthageKit/DerivedData/12.0_12A7209/plcrashreporter/7de33819a0a48e6fc19f28c0808baca4561d50d6/Build/Products/Release-iphonesimulator/libCrashReporter.a


▸ Building library libCrashReporter.a
▸ Processing Info.plist
▸ Touching CrashReporter.framework (in target 'CrashReporter iOS Framework' from project 'CrashReporter')
** BUILD FAILED **
```

## Related PRs or issues

[AB#82994](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/82994)
#131 
