### PR TITLE
Fix get the subtype of device architecture on iOS 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PLCrashReporter Change Log
 
+## Version 1.7.3
+
+* Fix get the subtype of device architecture on iOS 14.
+
 ## Version 1.7.2
 
 * Fix building on Xcode 12 beta.

--- a/Source/PLCrashReportTextFormatter.m
+++ b/Source/PLCrashReportTextFormatter.m
@@ -392,7 +392,7 @@ static NSInteger binaryImageSort(id binary1, id binary2, void *context);
                     
                 case CPU_TYPE_ARM64:
                     /* Apple includes subtype for ARM64 binaries. */
-                    switch (imageInfo.codeType.subtype) {
+                    switch (imageInfo.codeType.subtype & ~CPU_SUBTYPE_MASK) {
                         case CPU_SUBTYPE_ARM64_ALL:
                             archName = @"arm64";
                             break;

--- a/Source/PLCrashReportTextFormatter.m
+++ b/Source/PLCrashReportTextFormatter.m
@@ -371,7 +371,7 @@ static NSInteger binaryImageSort(id binary1, id binary2, void *context);
             switch (imageInfo.codeType.type) {
                 case CPU_TYPE_ARM:
                     /* Apple includes subtype for ARM binaries. */
-                    switch (imageInfo.codeType.subtype) {
+                    switch (imageInfo.codeType.subtype & ~CPU_SUBTYPE_MASK) {
                         case CPU_SUBTYPE_ARM_V6:
                             archName = @"armv6";
                             break;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with the sample apps?

## Description

When launching an application on iOS 14 the `archName` shows as `arm64-unknown` in the crash log.

## Related PRs or issues

#133
[AB#83063](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/83063)
