### PR TITLE
Fix iOS 8 deployment target warning when using SPM with Swift 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,10 +2,16 @@
 
 import PackageDescription
 
+#if swift(>=5.3)
+let ios = SupportedPlatform.iOS(.v9)
+#else
+let ios = SupportedPlatform.iOS(.v8)
+#endif
+
 let package = Package(
     name: "PLCrashReporter",
     platforms: [
-        .iOS(.v8),
+        ios,
         .macOS(.v10_10),
         .tvOS(.v9)
     ],


### PR DESCRIPTION
## Description

When using this repository for SPM with a Swift toolchain >= 5.3 it would create a warning like:

> The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99

This is correct, since Swift 5.3 cannot support iOS 8 anymore. However when using an older toolchain, iOS 8 support can still be available. 

## Related PRs or issues

https://github.com/microsoft/plcrashreporter/issues/130

## Misc

This PR resolves the aforementioned warning when using Xcode 12 and SPM
