### PR TITLE
Fix invalid return type of mach exception handler

### DIFF
--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -295,7 +295,7 @@ static kern_return_t mach_exception_callback (task_t task, thread_t thread, exce
     };
     if ((err = plcrash_async_thread_state_current(mach_exception_callback_live_cb, &live_ctx)) != PLCRASH_ESUCCESS) {
         PLCF_DEBUG("Failed to write live report: %d", err);
-        return false;
+        return KERN_FAILURE;
     }
 
     /* Call any post-crash callback */


### PR DESCRIPTION
The return type of this function is `kern_return_t`，however line 298 returns `false`  which means `KERN_SUCCESS` according to the definition `#define KERN_SUCCESS                    0` when writing report fails. It's supposed to be `KERN_FAILURE` rather than `KERN_SUCCESS` here. 

In some circumstances, the report folder in `Library/Caches` might be cleaned, so when an exception is thrown, the report would not be written successfully. However `mach_exception_callback` returns `KERN_SUCCESS` when writing the report. The thread would be resumed and exception would be thrown again and again.

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with the sample apps?

## Description

NA

## Related PRs or issues

NA

## Misc

The case could be reproduced by clean the `Library/Caches/com.plausiblelabs.crashreporter.data` before trigger a crash. 
