### PR TITLE
Crash in delete custom data

### DIFF
--- a/Source/PLCrashLogWriter.m
+++ b/Source/PLCrashLogWriter.m
@@ -275,6 +275,7 @@ static void plprotobuf_cbinary_data_nsstring_init (PLProtobufCBinaryData *data, 
 static void plprotobuf_cbinary_data_free (PLProtobufCBinaryData *data) {
     if (data != NULL && data->data != NULL) {
         free(data->data);
+        data->data = nil;
         data->len = 0;
     }
 }

--- a/Source/PLCrashLogWriter.m
+++ b/Source/PLCrashLogWriter.m
@@ -275,7 +275,7 @@ static void plprotobuf_cbinary_data_nsstring_init (PLProtobufCBinaryData *data, 
 static void plprotobuf_cbinary_data_free (PLProtobufCBinaryData *data) {
     if (data != NULL && data->data != NULL) {
         free(data->data);
-        data->data = nil;
+        data->data = NULL;
         data->len = 0;
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated? No
* [ ] Are tests passing locally? Yes
* [ ] Are the files formatted correctly? Yes
* [ ] Did you add unit tests? No
* [ ] Did you test your change with the sample apps? Yes

## Description

In my app, I add custom data for a session. If the session ends with no crash, I delete the custom data. After some tome, when a new session starts (in the same app execution), I add new custom data again. In this scenario, PLLC causes a crash as the cleanup when deleting custom data has a bug

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
