### PR TITLE
customize data path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 1.8.2 (Under development)
 
 * **[Fix]** Fix `double-quoted` warnings in Xcode 12.
-* Add an api to customize data path.
+* **[Feature]** Add an API to customize data path.
 
 ## Version 1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.8.2 (Under development)
 
 * **[Fix]** Fix `double-quoted` warnings in Xcode 12.
+* Add an api to customize data path.
 
 ## Version 1.8.1
 

--- a/Source/PLCrashReporter.h
+++ b/Source/PLCrashReporter.h
@@ -122,6 +122,7 @@ typedef struct PLCrashReporterCallbacks {
 + (PLCrashReporter *) sharedReporter PLCR_DEPRECATED;
 
 - (instancetype) initWithConfiguration: (PLCrashReporterConfig *) config;
+- (instancetype) initWithConfiguration: (PLCrashReporterConfig *) config basePath:(NSString*) basePath;
 
 - (BOOL) hasPendingCrashReport;
 

--- a/Source/PLCrashReporter.h
+++ b/Source/PLCrashReporter.h
@@ -122,7 +122,7 @@ typedef struct PLCrashReporterCallbacks {
 + (PLCrashReporter *) sharedReporter PLCR_DEPRECATED;
 
 - (instancetype) initWithConfiguration: (PLCrashReporterConfig *) config;
-- (instancetype) initWithConfiguration: (PLCrashReporterConfig *) config basePath:(NSString*) basePath;
+- (instancetype) initWithConfiguration: (PLCrashReporterConfig *) config basePath:(NSString *) basePath;
 
 - (BOOL) hasPendingCrashReport;
 

--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -377,8 +377,8 @@ static void uncaught_exception_handler (NSException *exception) {
 
 @interface PLCrashReporter (PrivateMethods)
 
-- (id) initWithBundle: (NSBundle *) bundle basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration;
-- (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration;
+- (id) initWithBundle: (NSBundle *) bundle basePath: (NSString *) basePath configuration: (PLCrashReporterConfig *) configuration;
+- (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion basePath: (NSString *) basePath configuration: (PLCrashReporterConfig *) configuration;
 
 #if PLCRASH_FEATURE_MACH_EXCEPTIONS
 - (PLCrashMachExceptionServer *) enableMachExceptionServerWithPreviousPortSet: (__strong PLCrashMachExceptionPortSet **) previousPortSet
@@ -428,7 +428,7 @@ static PLCrashReporter *sharedReporter = nil;
     static dispatch_once_t onceLock;
     dispatch_once(&onceLock, ^{
         if (sharedReporter == nil)
-            sharedReporter = [[PLCrashReporter alloc] initWithBundle: [NSBundle mainBundle] basePath:nil configuration: [PLCrashReporterConfig defaultConfiguration]];
+            sharedReporter = [[PLCrashReporter alloc] initWithBundle: [NSBundle mainBundle] basePath: nil configuration: [PLCrashReporterConfig defaultConfiguration]];
     });
     return sharedReporter;
 }
@@ -446,11 +446,12 @@ static PLCrashReporter *sharedReporter = nil;
  * @param configuration The configuration to be used by this reporter instance.
  */
 - (instancetype) initWithConfiguration: (PLCrashReporterConfig *) configuration {
-    return [self initWithBundle: [NSBundle mainBundle] basePath:nil configuration: configuration];
+    return [self initWithBundle: [NSBundle mainBundle] basePath: nil configuration: configuration];
 }
 
 /**
  * Initialize a new PLCrashReporter instance with the given configuration.
+ *
  * @param basePath The base path to save the crash data.
  * @param configuration The configuration to be used by this reporter instance.
  */
@@ -861,7 +862,6 @@ cleanup:
  */
 @implementation PLCrashReporter (PrivateMethods)
 
-
 /**
  * @internal
  *
@@ -877,7 +877,7 @@ cleanup:
  * @todo The appId and version values should be fetched from the PLCrashReporterConfig, once the API
  * has been extended to allow supplying these values.
  */
-- (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration {
+- (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion basePath: (NSString *) basePath configuration: (PLCrashReporterConfig *) configuration {
     /* Initialize our superclass */
     if ((self = [super init]) == nil)
         return nil;
@@ -909,7 +909,7 @@ cleanup:
  * @param basePath The base path for saving the crash data.
  * @param configuration The PLCrashReporter configuration to use for this instance.
  */
-- (id) initWithBundle: (NSBundle *) bundle basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration {
+- (id) initWithBundle: (NSBundle *) bundle basePath: (NSString *) basePath configuration: (PLCrashReporterConfig *) configuration {
     NSString *bundleIdentifier = [bundle bundleIdentifier];
     NSString *bundleVersion = [[bundle infoDictionary] objectForKey: (NSString *) kCFBundleVersionKey];
     NSString *bundleMarketingVersion = [[bundle infoDictionary] objectForKey: @"CFBundleShortVersionString"];
@@ -932,7 +932,7 @@ cleanup:
         bundleVersion = @"";
     }
 
-    return [self initWithApplicationIdentifier: bundleIdentifier appVersion: bundleVersion appMarketingVersion:bundleMarketingVersion basePath:basePath configuration: configuration];
+    return [self initWithApplicationIdentifier: bundleIdentifier appVersion: bundleVersion appMarketingVersion:bundleMarketingVersion basePath: basePath configuration: configuration];
 }
 
 #if PLCRASH_FEATURE_MACH_EXCEPTIONS

--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -922,11 +922,7 @@ cleanup:
     
     /* No occurances of '/' should ever be in a bundle ID, but just to be safe, we escape them */
     NSString *appIdPath = [applicationIdentifier stringByReplacingOccurrencesOfString: @"/" withString: @"_"];
-    
-    //NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    //NSString *cacheDir = [paths objectAtIndex: 0];
     _crashReportDirectory = [[basePath stringByAppendingPathComponent: PLCRASH_CACHE_DIR] stringByAppendingPathComponent: appIdPath];
-    
     return self;
 }
 
@@ -996,7 +992,6 @@ cleanup:
         PLCR_LOG("Warning -- bundle version unavailable");
         bundleVersion = @"";
     }
-    
     return [self initWithApplicationIdentifier: bundleIdentifier appVersion: bundleVersion appMarketingVersion:bundleMarketingVersion basePath:basePath configuration: configuration];
 }
 

--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -456,7 +456,7 @@ static PLCrashReporter *sharedReporter = nil;
  * @param configuration The configuration to be used by this reporter instance.
  */
 - (instancetype) initWithConfiguration: (PLCrashReporterConfig *) configuration basePath:(NSString*) basePath {
-    return [self initWithBundle: [NSBundle mainBundle] basePath:basePath configuration: configuration];
+    return [self initWithBundle: [NSBundle mainBundle] basePath: basePath configuration: configuration];
 }
 
 /**

--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -377,9 +377,7 @@ static void uncaught_exception_handler (NSException *exception) {
 
 @interface PLCrashReporter (PrivateMethods)
 
-- (id) initWithBundle: (NSBundle *) bundle configuration: (PLCrashReporterConfig *) configuration;
 - (id) initWithBundle: (NSBundle *) bundle basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration;
-- (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion configuration: (PLCrashReporterConfig *) configuration;
 - (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration;
 
 #if PLCRASH_FEATURE_MACH_EXCEPTIONS
@@ -430,7 +428,7 @@ static PLCrashReporter *sharedReporter = nil;
     static dispatch_once_t onceLock;
     dispatch_once(&onceLock, ^{
         if (sharedReporter == nil)
-            sharedReporter = [[PLCrashReporter alloc] initWithBundle: [NSBundle mainBundle] configuration: [PLCrashReporterConfig defaultConfiguration]];
+            sharedReporter = [[PLCrashReporter alloc] initWithBundle: [NSBundle mainBundle] basePath:nil configuration: [PLCrashReporterConfig defaultConfiguration]];
     });
     return sharedReporter;
 }
@@ -445,13 +443,17 @@ static PLCrashReporter *sharedReporter = nil;
 
 /**
  * Initialize a new PLCrashReporter instance with the given configuration.
- *
  * @param configuration The configuration to be used by this reporter instance.
  */
 - (instancetype) initWithConfiguration: (PLCrashReporterConfig *) configuration {
-    return [self initWithBundle: [NSBundle mainBundle] configuration: configuration];
+    return [self initWithBundle: [NSBundle mainBundle] basePath:nil configuration: configuration];
 }
 
+/**
+ * Initialize a new PLCrashReporter instance with the given configuration.
+ * @param basePath The base path to save the crash data.
+ * @param configuration The configuration to be used by this reporter instance.
+ */
 - (instancetype) initWithConfiguration: (PLCrashReporterConfig *) configuration basePath:(NSString*) basePath {
     return [self initWithBundle: [NSBundle mainBundle] basePath:basePath configuration: configuration];
 }
@@ -859,40 +861,6 @@ cleanup:
  */
 @implementation PLCrashReporter (PrivateMethods)
 
-/**
- * @internal
- *
- * This is the designated initializer, but it is not intended
- * to be called externally.
- *
- * @param applicationIdentifier The application identifier to be included in crash reports.
- * @param applicationVersion The application version number to be included in crash reports.
- * @param applicationMarketingVersion The application marketing version number to be included in crash reports.
- * @param configuration The PLCrashReporter configuration.
- *
- * @todo The appId and version values should be fetched from the PLCrashReporterConfig, once the API
- * has been extended to allow supplying these values.
- */
-- (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion configuration: (PLCrashReporterConfig *) configuration {
-    /* Initialize our superclass */
-    if ((self = [super init]) == nil)
-        return nil;
-
-    /* Save the configuration */
-    _config = configuration;
-    _applicationIdentifier = applicationIdentifier;
-    _applicationVersion = applicationVersion;
-    _applicationMarketingVersion = applicationMarketingVersion;
-    
-    /* No occurances of '/' should ever be in a bundle ID, but just to be safe, we escape them */
-    NSString *appIdPath = [applicationIdentifier stringByReplacingOccurrencesOfString: @"/" withString: @"_"];
-    
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString *cacheDir = [paths objectAtIndex: 0];
-    _crashReportDirectory = [[cacheDir stringByAppendingPathComponent: PLCRASH_CACHE_DIR] stringByAppendingPathComponent: appIdPath];
-    
-    return self;
-}
 
 /**
  * @internal
@@ -922,44 +890,15 @@ cleanup:
     
     /* No occurances of '/' should ever be in a bundle ID, but just to be safe, we escape them */
     NSString *appIdPath = [applicationIdentifier stringByReplacingOccurrencesOfString: @"/" withString: @"_"];
+    
+    if (basePath == nil) {
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        basePath = [paths objectAtIndex: 0];
+    }
     _crashReportDirectory = [[basePath stringByAppendingPathComponent: PLCRASH_CACHE_DIR] stringByAppendingPathComponent: appIdPath];
     return self;
 }
 
-
-/**
- * @internal
- * 
- * Derive the bundle identifier and version from @a bundle.
- *
- * @param bundle The application's main bundle.
- * @param configuration The PLCrashReporter configuration to use for this instance.
- */
-- (id) initWithBundle: (NSBundle *) bundle configuration: (PLCrashReporterConfig *) configuration {
-    NSString *bundleIdentifier = [bundle bundleIdentifier];
-    NSString *bundleVersion = [[bundle infoDictionary] objectForKey: (NSString *) kCFBundleVersionKey];
-    NSString *bundleMarketingVersion = [[bundle infoDictionary] objectForKey: @"CFBundleShortVersionString"];
-    
-    /* Verify that the identifier is available */
-    if (bundleIdentifier == nil) {
-        const char *progname = getprogname();
-        if (progname == NULL) {
-            [NSException raise: PLCrashReporterException format: @"Can not determine process identifier or process name"];
-            return nil;
-        }
-
-        PLCR_LOG("Warning -- bundle identifier, using process name %s", progname);
-        bundleIdentifier = [NSString stringWithUTF8String: progname];
-    }
-
-    /* Verify that the version is available */
-    if (bundleVersion == nil) {
-        PLCR_LOG("Warning -- bundle version unavailable");
-        bundleVersion = @"";
-    }
-    
-    return [self initWithApplicationIdentifier: bundleIdentifier appVersion: bundleVersion appMarketingVersion:bundleMarketingVersion configuration: configuration];
-}
 
 /**
  * @internal
@@ -992,6 +931,7 @@ cleanup:
         PLCR_LOG("Warning -- bundle version unavailable");
         bundleVersion = @"";
     }
+
     return [self initWithApplicationIdentifier: bundleIdentifier appVersion: bundleVersion appMarketingVersion:bundleMarketingVersion basePath:basePath configuration: configuration];
 }
 

--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -378,7 +378,9 @@ static void uncaught_exception_handler (NSException *exception) {
 @interface PLCrashReporter (PrivateMethods)
 
 - (id) initWithBundle: (NSBundle *) bundle configuration: (PLCrashReporterConfig *) configuration;
+- (id) initWithBundle: (NSBundle *) bundle basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration;
 - (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion configuration: (PLCrashReporterConfig *) configuration;
+- (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration;
 
 #if PLCRASH_FEATURE_MACH_EXCEPTIONS
 - (PLCrashMachExceptionServer *) enableMachExceptionServerWithPreviousPortSet: (__strong PLCrashMachExceptionPortSet **) previousPortSet
@@ -450,6 +452,9 @@ static PLCrashReporter *sharedReporter = nil;
     return [self initWithBundle: [NSBundle mainBundle] configuration: configuration];
 }
 
+- (instancetype) initWithConfiguration: (PLCrashReporterConfig *) configuration basePath:(NSString*) basePath {
+    return [self initWithBundle: [NSBundle mainBundle] basePath:basePath configuration: configuration];
+}
 
 /**
  * Returns YES if the application has previously crashed and
@@ -889,6 +894,42 @@ cleanup:
     return self;
 }
 
+/**
+ * @internal
+ *
+ * This is the designated initializer, but it is not intended
+ * to be called externally.
+ *
+ * @param applicationIdentifier The application identifier to be included in crash reports.
+ * @param applicationVersion The application version number to be included in crash reports.
+ * @param applicationMarketingVersion The application marketing version number to be included in crash reports.
+ * @param basePath The base path for saving the crash data. 
+ * @param configuration The PLCrashReporter configuration.
+ *
+ * @todo The appId and version values should be fetched from the PLCrashReporterConfig, once the API
+ * has been extended to allow supplying these values.
+ */
+- (id) initWithApplicationIdentifier: (NSString *) applicationIdentifier appVersion: (NSString *) applicationVersion appMarketingVersion: (NSString *) applicationMarketingVersion basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration {
+    /* Initialize our superclass */
+    if ((self = [super init]) == nil)
+        return nil;
+
+    /* Save the configuration */
+    _config = configuration;
+    _applicationIdentifier = applicationIdentifier;
+    _applicationVersion = applicationVersion;
+    _applicationMarketingVersion = applicationMarketingVersion;
+    
+    /* No occurances of '/' should ever be in a bundle ID, but just to be safe, we escape them */
+    NSString *appIdPath = [applicationIdentifier stringByReplacingOccurrencesOfString: @"/" withString: @"_"];
+    
+    //NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    //NSString *cacheDir = [paths objectAtIndex: 0];
+    _crashReportDirectory = [[basePath stringByAppendingPathComponent: PLCRASH_CACHE_DIR] stringByAppendingPathComponent: appIdPath];
+    
+    return self;
+}
+
 
 /**
  * @internal
@@ -922,6 +963,41 @@ cleanup:
     }
     
     return [self initWithApplicationIdentifier: bundleIdentifier appVersion: bundleVersion appMarketingVersion:bundleMarketingVersion configuration: configuration];
+}
+
+/**
+ * @internal
+ *
+ * Derive the bundle identifier and version from @a bundle.
+ *
+ * @param bundle The application's main bundle.
+ * @param basePath The base path for saving the crash data.
+ * @param configuration The PLCrashReporter configuration to use for this instance.
+ */
+- (id) initWithBundle: (NSBundle *) bundle basePath:(NSString*)basePath configuration: (PLCrashReporterConfig *) configuration {
+    NSString *bundleIdentifier = [bundle bundleIdentifier];
+    NSString *bundleVersion = [[bundle infoDictionary] objectForKey: (NSString *) kCFBundleVersionKey];
+    NSString *bundleMarketingVersion = [[bundle infoDictionary] objectForKey: @"CFBundleShortVersionString"];
+    
+    /* Verify that the identifier is available */
+    if (bundleIdentifier == nil) {
+        const char *progname = getprogname();
+        if (progname == NULL) {
+            [NSException raise: PLCrashReporterException format: @"Can not determine process identifier or process name"];
+            return nil;
+        }
+
+        PLCR_LOG("Warning -- bundle identifier, using process name %s", progname);
+        bundleIdentifier = [NSString stringWithUTF8String: progname];
+    }
+
+    /* Verify that the version is available */
+    if (bundleVersion == nil) {
+        PLCR_LOG("Warning -- bundle version unavailable");
+        bundleVersion = @"";
+    }
+    
+    return [self initWithApplicationIdentifier: bundleIdentifier appVersion: bundleVersion appMarketingVersion:bundleMarketingVersion basePath:basePath configuration: configuration];
 }
 
 #if PLCRASH_FEATURE_MACH_EXCEPTIONS


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [YES ] Has `CHANGELOG.md` been updated?
* [ YES] Are tests passing locally?
* [YES ] Are the files formatted correctly?
* [ NO] Did you add unit tests?
* [YES ] Did you test your change with the sample apps? 

## Description

Our app has a sub-process. When the app starts, it will start the sub-process which is a console app. The main app runs in sandbox on MacOS and can find the sandbox path, but the sub-process can not find the sandbox path correctly, so PLCrashReporter cann't write the crash info because of permission issue.

## Related PRs or issues

https://github.com/microsoft/plcrashreporter/issues/163

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
