### PR TITLE
Fix architecture issue when building on m1 for iOS simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PLCrashReporter Change Log
 
+## Version 1.9.1
+
+* **[Fix]** Fix error "Undefined symbols for architecture arm64" while building PLCrashReporter for simulator on Xcode 12.4+
+
 ## Version 1.9.0
 
 * **[Fix]** Fix `double-quoted` warnings in Xcode 12.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 1.9.1
 
-* **[Fix]** Fix error "Undefined symbols for architecture arm64" while building PLCrashReporter for simulator on Xcode 12.4 and higher.
+* **[Fix]** Fix error `Undefined symbols for architecture arm64` while building PLCrashReporter for simulator on Xcode 12.4 and higher.
 
 ## Version 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 1.9.1
 
-* **[Fix]** Fix error "Undefined symbols for architecture arm64" while building PLCrashReporter for simulator on Xcode 12.4+
+* **[Fix]** Fix error "Undefined symbols for architecture arm64" while building PLCrashReporter for simulator on Xcode 12.4 and higher.
 
 ## Version 1.9.0
 

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -3674,7 +3674,6 @@
 					armv7s,
 					arm64e,
 				);
-				"ARCHS[sdk=iphonesimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				DEFINES_MODULE = YES;
 				GENERATE_MASTER_OBJECT_FILE = YES;
@@ -3699,7 +3698,6 @@
 					armv7s,
 					arm64e,
 				);
-				"ARCHS[sdk=iphonesimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				DEFINES_MODULE = YES;
@@ -3740,7 +3738,6 @@
 					armv7s,
 					arm64e,
 				);
-				"ARCHS[sdk=iphonesimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				MACH_O_TYPE = staticlib;
 				OTHER_CFLAGS = "-fembed-bitcode-marker";
@@ -3760,7 +3757,6 @@
 					armv7s,
 					arm64e,
 				);
-				"ARCHS[sdk=iphonesimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				BITCODE_GENERATION_MODE = bitcode;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				MACH_O_TYPE = staticlib;
@@ -3803,7 +3799,6 @@
 		05CD33270EE9443A000FDE88 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"ARCHS[sdk=iphonesimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				DEVELOPMENT_TEAM = 5Z97G9NZQ6;
 				INFOPLIST_FILE = "Resources/Tests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:rfc1034identifier}";
@@ -3817,7 +3812,6 @@
 		05CD33280EE9443A000FDE88 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"ARCHS[sdk=iphonesimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				DEVELOPMENT_TEAM = 5Z97G9NZQ6;
 				INFOPLIST_FILE = "Resources/Tests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:rfc1034identifier}";
@@ -4004,7 +3998,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LIBTOOLFLAGS = "-no_warning_for_no_symbols";
-				PL_SIMULATOR_ARCHS = "i386 x86_64";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:identifier}";
 				PRODUCT_NAME = CrashReporter;
 				PROTOBUF_C_UNPACK_ERROR = PLCF_DEBUG;
@@ -4067,7 +4060,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_LIBTOOLFLAGS = "-no_warning_for_no_symbols";
-				PL_SIMULATOR_ARCHS = "i386 x86_64";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:identifier}";
 				PRODUCT_NAME = CrashReporter;
 				PROTOBUF_C_UNPACK_ERROR = PLCF_DEBUG;
@@ -4080,7 +4072,6 @@
 		8064D8191C4D22D8005A8B4C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"ARCHS[sdk=appletvsimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				MACH_O_TYPE = staticlib;
 				OTHER_CFLAGS = "-fembed-bitcode-marker";
@@ -4093,7 +4084,6 @@
 		8064D81A1C4D22D8005A8B4C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"ARCHS[sdk=appletvsimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				BITCODE_GENERATION_MODE = bitcode;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				MACH_O_TYPE = staticlib;
@@ -4108,7 +4098,6 @@
 		8064D8B91C4D22E5005A8B4C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"ARCHS[sdk=appletvsimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -4128,7 +4117,6 @@
 		8064D8BA1C4D22E5005A8B4C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"ARCHS[sdk=appletvsimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Manual;
@@ -4150,7 +4138,6 @@
 		8064D9931C4D27E2005A8B4C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"ARCHS[sdk=appletvsimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				DEVELOPMENT_TEAM = 5Z97G9NZQ6;
 				INFOPLIST_FILE = "Resources/Tests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:rfc1034identifier}";
@@ -4163,7 +4150,6 @@
 		8064D9941C4D27E2005A8B4C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"ARCHS[sdk=appletvsimulator*]" = "$(PL_SIMULATOR_ARCHS)";
 				DEVELOPMENT_TEAM = 5Z97G9NZQ6;
 				INFOPLIST_FILE = "Resources/Tests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:rfc1034identifier}";


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* ~[ ] Are the files formatted correctly?~
* ~[ ] Did you add unit tests?~
* [x] Did you test your change with the sample apps?

## Description

This PR fixes the following build errors if building on mac m1 for ios simulator:
```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_MSPLCrashReporter", referenced from:
      objc-class-ref in AppCenterCrashes(MSACCrashes.o)
  "_OBJC_CLASS_$_MSPLCrashReport", referenced from:
      objc-class-ref in AppCenterCrashes(MSACCrashes.o)
  "_OBJC_CLASS_$_MSPLCrashReporterConfig", referenced from:
      objc-class-ref in AppCenterCrashes(MSACCrashes.o)
ld: symbol(s) not found for architecture arm64

```

## Related PRs or issues

[AB#86888](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/86888)
https://github.com/microsoft/appcenter-sdk-apple/issues/1621