### PR TITLE
Fix a build error if the source folder has a space

### DIFF
--- a/Scripts/combine-frameworks.sh
+++ b/Scripts/combine-frameworks.sh
@@ -10,7 +10,8 @@ cp -Rv "$1" "$3"
 # Combining libraries.
 product_name=${1##*/}
 product_name=${product_name%.*}
-$(dirname "$0")/combine-libraries.sh \
+script_folder=$(dirname "$0")
+"${script_folder}"/combine-libraries.sh \
     "$1/${product_name}" \
     "$2/${product_name}" \
     "$3/${product_name}"


### PR DESCRIPTION
If the source folder has a space in the path then the build for iOS fails as $(dirname "$0")/combine-libraries.sh has a space in it. This changes adds quotes around the directory name.

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [N/A] Has `CHANGELOG.md` been updated?
* [Y] Are tests passing locally? 
* [Y] Are the files formatted correctly?
* [N/A ] Did you add unit tests?
* [Y] Did you test your change with the sample apps?

## Description

Allow the project to build if the source folder has a space in the path

## Related PRs or issues

List related PRs and other issues.

## Misc

Did a visual review of other scripts in the Scripts folder and they seem to be ok.
