### PR TITLE
Add pragmas to disable false positive warning

### DIFF
--- a/Source/PLCrashMachExceptionServer.m
+++ b/Source/PLCrashMachExceptionServer.m
@@ -531,6 +531,9 @@ kern_return_t PLCrashMachExceptionForward (task_t task,
                                            mach_msg_type_number_t code_count,
                                            plcrash_mach_exception_port_set_t *port_state)
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wconditional-uninitialized"
+
     exception_behavior_t behavior;
     thread_state_flavor_t flavor;
     mach_port_t port;
@@ -630,6 +633,7 @@ kern_return_t PLCrashMachExceptionForward (task_t task,
     
     PLCF_DEBUG("Unsupported exception behavior: 0x%x (MACH_EXCEPTION_CODES=%s)", behavior, mach_exc_codes ? "true" : "false");
     return KERN_FAILURE;
+#pragma clang diagnostic pop
 }
 
 

--- a/Source/PLCrashMachExceptionServer.m
+++ b/Source/PLCrashMachExceptionServer.m
@@ -532,6 +532,12 @@ kern_return_t PLCrashMachExceptionForward (task_t task,
                                            plcrash_mach_exception_port_set_t *port_state)
 {
 #pragma clang diagnostic push
+/**
+ * Disable uninitialized variable warnings for `behavior`, `flavor`, `port` and `thread_state_count` which will be triggered 
+ * if the build setting for Uninitialized Variables Warning is Yes (Aggressive)
+ * behavior, flavor and port can be seen to be either initialized in the loop (found -> true) or the function will exit (found -> false)
+ * thread_state_count will be initialized for all cases except behavior == EXCEPTION_DEFAULT, in which case the thread_state_count is not used in the `switch (behavior)` block
+ */
 #pragma clang diagnostic ignored "-Wconditional-uninitialized"
 
     exception_behavior_t behavior;


### PR DESCRIPTION
There are warning messages about `Variable 'behavior' may be uninitialized when used here` (also for `flavor` and `port`) from the test at line 559 they wont be used uninitialised so this change adds a #pragma wrap around the code to suppress the warnings.

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [N/A] Has `CHANGELOG.md` been updated?
* [Yes] Are tests passing locally?
* [Yes] Are the files formatted correctly?
* [N/A] Did you add unit tests?
* [ ] Did you test your change with the sample apps?

## Description

Removes build warnings

## Related PRs or issues

N/A

## Misc

Should there be a comment about why pragmas are added? Can the `pop` be moved further up to limit area changed?
