### PR TITLE
Fix cycle in dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.9.1
 
 * **[Fix]** Fix error `Undefined symbols for architecture arm64` while building PLCrashReporter for simulator on Xcode 12.4 and higher.
+* **[Fix]** Fix Cycle in dependencies error happening when building project from sources multiple times.
 
 ## Version 1.9.0
 

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -69,9 +69,6 @@
 				C2C74DD1253851C300313817 /* Copy Products */,
 			);
 			dependencies = (
-				C2C74DC8253850A500313817 /* PBXTargetDependency */,
-				C2C74DC6253850A500313817 /* PBXTargetDependency */,
-				C2C74DCA253850A500313817 /* PBXTargetDependency */,
 				C2C74DC4253850A500313817 /* PBXTargetDependency */,
 				C2C74DCC253850A500313817 /* PBXTargetDependency */,
 				C2C74DCE253850A500313817 /* PBXTargetDependency */,
@@ -902,27 +899,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = F8B9C72A24695BE600B9FEF6;
 			remoteInfo = "CrashReporter XCFramework";
-		};
-		C2C74DC5253850A500313817 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C2B90D952456FBD000834AFB;
-			remoteInfo = "CrashReporter iOS Universal";
-		};
-		C2C74DC7253850A500313817 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8DC2EF4F0486A6940098B216;
-			remoteInfo = "CrashReporter macOS Framework";
-		};
-		C2C74DC9253850A500313817 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C2B90D992456FBDE00834AFB;
-			remoteInfo = "CrashReporter tvOS Universal";
 		};
 		C2C74DCB253850A500313817 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -3565,21 +3541,6 @@
 			isa = PBXTargetDependency;
 			target = F8B9C72A24695BE600B9FEF6 /* CrashReporter XCFramework */;
 			targetProxy = C2C74DC3253850A500313817 /* PBXContainerItemProxy */;
-		};
-		C2C74DC6253850A500313817 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C2B90D952456FBD000834AFB /* CrashReporter iOS Universal */;
-			targetProxy = C2C74DC5253850A500313817 /* PBXContainerItemProxy */;
-		};
-		C2C74DC8253850A500313817 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 8DC2EF4F0486A6940098B216 /* CrashReporter macOS Framework */;
-			targetProxy = C2C74DC7253850A500313817 /* PBXContainerItemProxy */;
-		};
-		C2C74DCA253850A500313817 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C2B90D992456FBDE00834AFB /* CrashReporter tvOS Universal */;
-			targetProxy = C2C74DC9253850A500313817 /* PBXContainerItemProxy */;
 		};
 		C2C74DCC253850A500313817 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* ~[ ] Are the files formatted correctly?~
* ~[ ] Did you add unit tests?~
* [x] Did you test your change with the sample apps?

## Description

This PR fixes "Cycle in dependencies" error when building `CrashReporter` target.
Removed redundant dependencies (`CrashReporter macOS`, `CrashReporter IOS Universal `, `CrashReporter tvOS Universal `) from target `CrashReporter`, because they are part of dependency `CrashReporter XCFramework`, and also added a parallel build, and this solved the problem. 

## Related PRs or issues
#194

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
