### PR TITLE
Use a static XCFramework for Carthage

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -108,7 +108,6 @@ jobs:
       VERSION="$(cd $BUILD_SOURCESDIRECTORY && agvtool vers -terse)"
       [[ $BUILD_SOURCEBRANCH != 'refs/heads/master' ]] && VERSION="$VERSION+$(cd $BUILD_SOURCESDIRECTORY && git rev-parse --short $BUILD_SOURCEVERSION)"
       "$BUILD_SOURCESDIRECTORY/Scripts/create-archive.sh" "PLCrashReporter-$VERSION" "iOS Framework" "tvOS Framework" "Mac OS X Framework" "Tools"
-      "$BUILD_SOURCESDIRECTORY/Scripts/create-archive.sh" "PLCrashReporter-$VERSION.carthage.framework" "iOS Framework" "tvOS Framework" "Mac OS X Framework" "Tools"
       "$BUILD_SOURCESDIRECTORY/Scripts/create-archive.sh" "PLCrashReporter-Static-$VERSION" Static/*
       "$BUILD_SOURCESDIRECTORY/Scripts/create-archive.sh" "PLCrashReporter-XCFramework-$VERSION" "CrashReporter.xcframework"
       "$BUILD_SOURCESDIRECTORY/Scripts/create-archive.sh" "PLCrashReporter-Static-$VERSION.xcframework" "PLCrashReporterStatic/CrashReporter.xcframework"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 * **[Fix]** Fix error `Undefined symbols for architecture arm64` while building PLCrashReporter for simulator on Xcode 12.4 and higher.
 * **[Fix]** Fix Cycle in dependencies error happening when building project from sources multiple times.
-* **[Feature]** Distribute XCFramework via Cocoapods. The XCFramework will contain static libs only.
-* **[Feature]** Distribute XCFramework via Carthage. The XCFramework will contain static libs only.
+* **[Feature]** Distribute XCFramework via Cocoapods and Carthage. The XCFramework will contain static libs only.
 
 ## Version 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * **[Fix]** Fix error `Undefined symbols for architecture arm64` while building PLCrashReporter for simulator on Xcode 12.4 and higher.
 * **[Fix]** Fix Cycle in dependencies error happening when building project from sources multiple times.
 * **[Feature]** Distribute XCFramework via Cocoapods. The XCFramework will contain static libs only.
+* **[Feature]** Distribute XCFramework via Carthage. The XCFramework will contain static libs only.
 
 ## Version 1.9.0
 

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 				C25664E62357487D0088513E /* Create Archive With Static Libraries */,
 				F8CF2BD2246C139400904633 /* Create Archive With XCFramework */,
 				061DB46526E0B73500913209 /* Create Archive With Static XCFramework */,
-				D5A991BC2670C84D000A0F97 /* Create Archive Carthage */,
 			);
 			dependencies = (
 				C2C74E1D25385F5B00313817 /* PBXTargetDependency */,
@@ -3302,25 +3301,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "DEVICE_LIBRARY=\"$BUILD_DIR/$CONFIGURATION-appletvos/lib$PRODUCT_NAME.a\"\nSIMULATOR_LIBRARY=\"$BUILD_DIR/$CONFIGURATION-appletvsimulator/lib$PRODUCT_NAME.a\"\n\"$SRCROOT/Scripts/combine-libraries.sh\" \"$DEVICE_LIBRARY\" \"$SIMULATOR_LIBRARY\" \"$BUILT_PRODUCTS_DIR/lib$PRODUCT_NAME.a\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D5A991BC2670C84D000A0F97 /* Create Archive Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Create Archive Carthage";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "cd \"$BUILT_PRODUCTS_DIR\"\n\"$SRCROOT/Scripts/create-archive.sh\" \"$PRODUCT_NAME-$CURRENT_PROJECT_VERSION.carthage.framework\" Static/* \"Tools\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B9C72E24695BF200B9FEF6 /* Combine XCFramework */ = {

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ PLCrashReporter can be added to your app via [CocoaPods](https://guides.cocoapod
     ```ruby
     github "microsoft/plcrashreporter"
     ```
-1. Run `carthage update` to fetch dependencies.
-1. Open your application target's **General** settings tab. Drag and drop **CrashReporter.framework** from **Carthage/Build/{platform}** folder into Xcode's Project Navigator.
+1. Run `carthage update --use-xcframeworks` to fetch dependencies.
+2. Open your application target's **General** settings tab. Drag and drop **CrashReporter.xcframework** from **Carthage/Build** folder into Xcode's Project Navigator.
 
 > **NOTE:**
 > Carthage integration doesn't build the dependency correctly in Xcode 12 with flag "--no-use-binaries" or from a specific branch. To make it work, refer to [this instruction](https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md).


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* ~[ ] Are tests passing locally?~
* ~[ ] Are the files formatted correctly?~
* ~[ ] Did you add unit tests?~
* [x] Did you test your change with the sample apps?

## Description

Remove usage of a fat framework for Carthage. Instead use the [added in previous PR](https://github.com/microsoft/plcrashreporter/pull/209) static XCFramework.
Carthage will pick it because of the file ends with `xcframework.zip`.
Usage: `carthage update --use-xcframeworks`.

## Related PRs or issues

[AB#87784](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/87784)
https://github.com/microsoft/plcrashreporter/pull/209
