### PR TITLE
Use passed value of shouldRegisterUncaughtExceptionHandler instead of YES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 1.10.2 (Under development)
 
-* **[Fix]** PLCrashReporterConfig is always setting shouldRegisterUncaughtExceptionHandler to YES in ctor.
+* **[Fix]** Config ignored `shouldRegisterUncaughtExceptionHandler` parameter in constructor.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PLCrashReporter Change Log
 
+## Version 1.10.2 (Under development)
+
+* **[Fix]** PLCrashReporterConfig is always setting shouldRegisterUncaughtExceptionHandler to YES in ctor.
+
+___
+
 ## Version 1.10.1
 
 * **[Improvement]** Specified minimum cocoapods version in podspec to 1.10.0

--- a/Source/PLCrashReporterConfig.m
+++ b/Source/PLCrashReporterConfig.m
@@ -106,7 +106,7 @@
                      symbolicationStrategy: (PLCrashReporterSymbolicationStrategy) symbolicationStrategy
     shouldRegisterUncaughtExceptionHandler: (BOOL) shouldRegisterUncaughtExceptionHandler
 {
-  return [self initWithSignalHandlerType: signalHandlerType symbolicationStrategy: symbolicationStrategy shouldRegisterUncaughtExceptionHandler: YES basePath: nil];
+  return [self initWithSignalHandlerType: signalHandlerType symbolicationStrategy: symbolicationStrategy shouldRegisterUncaughtExceptionHandler: shouldRegisterUncaughtExceptionHandler basePath: nil];
 }
 
 /**


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with the sample apps?

## Description

This PR fixes the behaviour of PLCrashReporterConfig initialisation that didn't take into account the passed property `shouldRegisterUncaughtExceptionHandler` in method:
```objc
- (instancetype) initWithSignalHandlerType: (PLCrashReporterSignalHandlerType) signalHandlerType
                     symbolicationStrategy: (PLCrashReporterSymbolicationStrategy) symbolicationStrategy
    shouldRegisterUncaughtExceptionHandler: (BOOL) shouldRegisterUncaughtExceptionHandler
```

## Related PRs or issues

[AB#92529](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/92529)
#236
https://github.com/microsoft/appcenter-sdk-dotnet/issues/1639