### PR TITLE
Fix Xcode 13 incremental builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **[Fix]** Config ignored `shouldRegisterUncaughtExceptionHandler` parameter in constructor.
 * **[Improvement]** Update `protobuf-c` to version 1.4.0.
+* **[Improvement]** Fix Xcode 13 deprecated build settings that might broke incremental builds (it drops workaround for Xcode's 12.0-12.4 bug). It only affects projects that use PLCrashReporter as sources.
 
 ___
 

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -2673,7 +2673,8 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1140;
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1340;
 				TargetAttributes = {
 					052A45CE136353FB00987004 = {
 						DevelopmentTeam = 5Z97G9NZQ6;
@@ -4060,6 +4061,7 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -4072,6 +4074,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -4125,6 +4128,7 @@
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -4137,6 +4141,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -4350,7 +4355,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EFFECTIVE_PLATFORM_NAME = "-iphoneuniversal";
-				MODULEMAP_FILE = Resources/CrashReporter.modulemap;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -4359,7 +4363,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EFFECTIVE_PLATFORM_NAME = "-iphoneuniversal";
-				MODULEMAP_FILE = Resources/CrashReporter.modulemap;
 				SDKROOT = iphoneos;
 			};
 			name = Release;
@@ -4368,7 +4371,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EFFECTIVE_PLATFORM_NAME = "-appletvuniversal";
-				MODULEMAP_FILE = Resources/CrashReporter.modulemap;
 				SDKROOT = appletvos;
 			};
 			name = Debug;
@@ -4377,7 +4379,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EFFECTIVE_PLATFORM_NAME = "-appletvuniversal";
-				MODULEMAP_FILE = Resources/CrashReporter.modulemap;
 				SDKROOT = appletvos;
 			};
 			name = Release;

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter Archive.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter Archive.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter Documentation.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter Documentation.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter XCFramework.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter XCFramework.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter iOS Framework.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter iOS Framework.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter iOS Universal.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter iOS Universal.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter iOS.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter macOS Framework.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter macOS Framework.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter macOS Static Framework.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter macOS Static Framework.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter macOS.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter tvOS Framework.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter tvOS Framework.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter tvOS Universal.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter tvOS Universal.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter tvOS.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/CrashReporter.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash iOS.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash iOS.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash macOS.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash macOS.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash tvOS.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/DemoCrash tvOS.xcscheme
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/Fuzz Testing.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/Fuzz Testing.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CrashReporter.xcodeproj/xcshareddata/xcschemes/plcrashutil.xcscheme
+++ b/CrashReporter.xcodeproj/xcshareddata/xcschemes/plcrashutil.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with the sample apps?

## Description

`parallelizeBuildables` is deprecated now and might cause incremental build issues.
`CLANG_MODULES_AUTOLINK` might cause implicit dependencies search, so it's disabled now.
`MODULEMAP_FILE` is not needed for script targets. (Clean up dependencies graph).
Also, applied new recommended by Xcode 13 warning settings.

## Related PRs or issues

#131
#240
[AB#93651](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/93651)

