### PR TITLE
Fix parsing args in plcrashutil

### DIFF
--- a/Other Sources/plcrashutil/main.m
+++ b/Other Sources/plcrashutil/main.m
@@ -40,7 +40,7 @@ static void print_usage () {
     fprintf(stderr, "Usage: plcrashutil <command> <options>\n"
                     "Commands:\n"
                     "  convert --format=<format> <file>\n"
-                    "      Covert a plcrash file to the given format.\n\n"
+                    "      Convert a plcrash file to the given format.\n\n"
                     "      Supported formats:\n"
                     "        ios - Standard Apple iOS-compatible text crash log\n"
                     "        iphone - Synonym for 'iOS'.\n");

--- a/Other Sources/plcrashutil/main.m
+++ b/Other Sources/plcrashutil/main.m
@@ -86,7 +86,7 @@ static int convert_command (int argc, char *argv[]) {
     
     /* Verify that the format is supported. Only one is actually supported currently */
     PLCrashReportTextFormat textFormat;
-    if (strcasecmp(format, "iphone") == 0 || strcasecmp(format, "ios")) {
+    if (strcasecmp(format, "iphone") == 0 || strcasecmp(format, "ios") == 0) {
         textFormat = PLCrashReportTextFormatiOS;
     } else {
         fprintf(stderr, "Unsupported format requested\n");
@@ -127,7 +127,7 @@ int main (int argc, char *argv[]) {
 
         /* Convert command */
         if (strcmp(argv[1], "convert") == 0) {
-            ret = convert_command(argc - 2, argv + 2);
+            ret = convert_command(argc - 1, argv + 1);
         } else {
             print_usage();
             ret = 1;


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with the sample apps?

## Description

Args parsing was broken, but in a way that default one was applied. In fact there is only one option now, so it changes nothing in terms of "changelog"

[AB#94527](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/94527)
