### PR TITLE
Change deprecated constant name

### DIFF
--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -489,7 +489,7 @@ static PLCrashReporter *sharedReporter = nil;
  */
 - (NSData *) loadPendingCrashReportDataAndReturnError: (NSError **) outError {
     /* Load the (memory mapped) data */
-    return [NSData dataWithContentsOfFile: [self crashReportPath] options: NSMappedRead error: outError];
+    return [NSData dataWithContentsOfFile: [self crashReportPath] options: NSDataReadingMappedIfSafe error: outError];
 }
 
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with the sample apps?

## Description

Change deprecated constant name 
`NSDataReadingMappedIfSafe`

https://developer.apple.com/documentation/foundation/nsdatareadingoptions?language=objc

## Related PRs or issues

N/A

## Misc

N/A
