### PR TITLE
Added caught exception logging to PLCrashReporter

### DIFF
--- a/Source/PLCrashReporter.h
+++ b/Source/PLCrashReporter.h
@@ -130,9 +130,11 @@ typedef struct PLCrashReporterCallbacks {
 
 - (NSData *) generateLiveReportWithThread: (thread_t) thread;
 - (NSData *) generateLiveReportWithThread: (thread_t) thread error: (NSError **) outError;
+- (NSData *) generateLiveReportWithThread: (thread_t) thread exception: (NSException *) exception error: (NSError **) outError;
 
 - (NSData *) generateLiveReport;
 - (NSData *) generateLiveReportAndReturnError: (NSError **) outError;
+- (NSData *) generateLiveReportWithException: (NSException *) exception error: (NSError **) outError;
 
 - (BOOL) purgePendingCrashReport;
 - (BOOL) purgePendingCrashReportAndReturnError: (NSError **) outError;

--- a/Source/PLCrashReporter.m
+++ b/Source/PLCrashReporter.m
@@ -653,13 +653,28 @@ static PLCrashReporter *sharedReporter = nil;
  *
  * @return Returns nil if the crash report data could not be generated.
  *
- * @sa PLCrashReporter::generateLiveReportWithMachThread:error:
+ * @sa PLCrashReporter::generateLiveReportWithThread:exception:error:
  */
 - (NSData *) generateLiveReportWithThread: (thread_t) thread {
     return [self generateLiveReportWithThread: thread error: NULL];
 }
 
-- (NSData *) generateLiveReportWithThread:(thread_t)thread error:(NSError **)outError {
+/**
+ * Generate a live crash report for a given @a thread, without triggering an actual crash condition.
+ * This may be used to log current process state without actually crashing. The crash report data will be
+ * returned on success.
+ *
+ * @param thread The thread which will be marked as the failing thread in the generated report.
+ * @param outError A pointer to an NSError object variable. If an error occurs, this pointer
+ * will contain an error object indicating why the crash report could not be generated or loaded. If no
+ * error occurs, this parameter will be left unmodified. You may specify nil for this parameter, and no
+ * error information will be provided.
+ *
+ * @return Returns nil if the crash report data could not be loaded.
+ *
+ * @sa PLCrashReporter::generateLiveReportWithThread:exception:error:
+ */
+- (NSData *) generateLiveReportWithThread: (thread_t) thread error: (NSError **) outError {
     return [self generateLiveReportWithThread: thread exception: nil error: outError];
 }
 
@@ -682,6 +697,7 @@ static plcrash_error_t plcr_live_report_callback (plcrash_async_thread_state_t *
  * returned on success.
  *
  * @param thread The thread which will be marked as the failing thread in the generated report.
+ * @param exception An exception to be included as the report's uncaught exception, or nil.
  * @param outError A pointer to an NSError object variable. If an error occurs, this pointer
  * will contain an error object indicating why the crash report could not be generated or loaded. If no
  * error occurs, this parameter will be left unmodified. You may specify nil for this parameter, and no
@@ -717,9 +733,8 @@ static plcrash_error_t plcr_live_report_callback (plcrash_async_thread_state_t *
         plcrash_log_writer_set_custom_data(&writer, self.customData);
     }
     
-    if (exception) {
+    if (exception != nil)
         plcrash_log_writer_set_exception(&writer, exception);
-    }
     
     /* Mock up a SIGTRAP-based signal info */
     plcrash_log_bsd_signal_info_t bsd_signal_info;

--- a/Tests/PLCrashReporterTests.m
+++ b/Tests/PLCrashReporterTests.m
@@ -47,6 +47,39 @@
 }
 
 /**
+ * Test generation of a 'live' crash report with a provided exception.
+ */
+- (void) testGenerateLiveReportWithException {
+    NSError *error;
+    NSData *reportData;
+    plcrash_test_thread_t thr;
+    
+    /* Spawn a thread and generate a report for it */
+    plcrash_test_thread_spawn(&thr);
+
+    NSException *exc = [NSException exceptionWithName: NSInvalidArgumentException reason: @"Testing" userInfo: nil];
+    PLCrashReporter *reporter = [[[PLCrashReporter alloc] initWithConfiguration: [PLCrashReporterConfig defaultConfiguration]] autorelease];
+    reportData = [reporter generateLiveReportWithThread: pthread_mach_thread_np(thr.thread)
+                                              exception: exc
+                                                  error: &error];
+    plcrash_test_thread_stop(&thr);
+    STAssertNotNil(reportData, @"Failed to generate live report: %@", error);
+    
+    /* Try parsing the result */
+    PLCrashReport *report = [[[PLCrashReport alloc] initWithData: reportData error: &error] autorelease];
+    STAssertNotNil(report, @"Could not parse geneated live report: %@", error);
+    
+    /* Sanity check the signal info */
+    STAssertEqualStrings([[report signalInfo] name], @"SIGTRAP", @"Incorrect signal name");
+    STAssertEqualStrings([[report signalInfo] code], @"TRAP_TRACE", @"Incorrect signal code");
+
+    /* Sanity check the exception info */
+    STAssertNotNil(report.exceptionInfo, @"Missing exception info");
+    STAssertEqualStrings(report.exceptionInfo.exceptionName, exc.name, @"Incorrect exception name");
+    STAssertEqualStrings(report.exceptionInfo.exceptionReason, exc.reason, @"Incorrect exception reason");
+}
+
+/**
  * Test generation of a 'live' crash report for a specific thread.
  */
 - (void) testGenerateLiveReportWithThread {

--- a/Tests/PLCrashReporterTests.m
+++ b/Tests/PLCrashReporterTests.m
@@ -58,7 +58,7 @@
     plcrash_test_thread_spawn(&thr);
 
     NSException *exc = [NSException exceptionWithName: NSInvalidArgumentException reason: @"Testing" userInfo: nil];
-    PLCrashReporter *reporter = [[[PLCrashReporter alloc] initWithConfiguration: [PLCrashReporterConfig defaultConfiguration]] autorelease];
+    PLCrashReporter *reporter = [[PLCrashReporter alloc] initWithConfiguration: [PLCrashReporterConfig defaultConfiguration]];
     reportData = [reporter generateLiveReportWithThread: pthread_mach_thread_np(thr.thread)
                                               exception: exc
                                                   error: &error];
@@ -66,7 +66,7 @@
     STAssertNotNil(reportData, @"Failed to generate live report: %@", error);
     
     /* Try parsing the result */
-    PLCrashReport *report = [[[PLCrashReport alloc] initWithData: reportData error: &error] autorelease];
+    PLCrashReport *report = [[PLCrashReport alloc] initWithData: reportData error: &error];
     STAssertNotNil(report, @"Could not parse geneated live report: %@", error);
     
     /* Sanity check the signal info */


### PR DESCRIPTION
## Description

I bring back the caught exception logging. I simply cherry-pick the commit 969602123a4e8d124755d1d90b558f94ab1ca6b7 that has been reverted by 48e516013a897438a0699261ca070b0c2da72510. 

We use that feature to generate reports from specific exception that have been caught elsewhere in the app.