### PR TITLE
[Fix] Add checks to ensure PLCrashReportExceptionInfo has non-nil name and reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.11.2 (In Development)
 
 * **[Improvement]** Update PLCrashReporter to include privacy manifest.
+* **[Fix]** Fix name/reason of PLCrashReportExceptionInfo could be nil.
 
 ___
 

--- a/Source/PLCrashReport.m
+++ b/Source/PLCrashReport.m
@@ -789,7 +789,23 @@ error:
     /* Done */
     NSString *name = [NSString stringWithUTF8String: exceptionInfo->name];
     NSString *reason = [NSString stringWithUTF8String: exceptionInfo->reason];
-    
+
+    /* Name not nil? */
+    if (name == nil) {
+        populate_nserror(outError, PLCrashReporterErrorCrashReportInvalid,
+                         NSLocalizedString(@"Crash report exception name is N/A as UTF8 String",
+                                           @"Missing appinfo operating system in crash report"));
+        return nil;
+    }
+
+    /* Reason not nil? */
+    if (reason == nil) {
+        populate_nserror(outError, PLCrashReporterErrorCrashReportInvalid,
+                         NSLocalizedString(@"Crash report exception reason is N/A as UTF8 String",
+                                           @"Missing appinfo operating system in crash report"));
+        return nil;
+    }
+
     /* Fetch stack frames for this thread */
     NSMutableArray *frames = nil;
     if (exceptionInfo->n_frames > 0) {


### PR DESCRIPTION
## Description

We encountered a system exception crash [here](https://github.com/microsoft/appcenter-sdk-apple/blob/4bc5282dfc6c273a993e67d8f8c61d8014d257e0/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m#L636) on Outlook iOS when copying `PLCrashReport.exceptionInfo.exceptionReason` but it was nil.

By going through the code, this can only happen when `[NSString stringWithUTF8String:]` returns nil [here](https://github.com/microsoft/plcrashreporter/blob/c071a07986a527d961383558e0604a456fb64b92/Source/PLCrashReport.m#L791). Since the `name` and `reason` are desgined to be non-nil, this PR fixes this edge case by verifying them to be non-nil as expected.