### PR TITLE
Fix build pipeline

### DIFF
--- a/.azure-pipelines/build-plcrashreporter-1ES.yml
+++ b/.azure-pipelines/build-plcrashreporter-1ES.yml
@@ -48,7 +48,7 @@ extends:
             sbomEnabled: false
         steps:
         - checkout: self
-        - bash: 'brew install doxygen graphviz protobuf-c'
+        - bash: 'brew install doxygen graphviz'
           displayName: 'Install dependencies'
         - task: Xcode@5
           displayName: 'Build Crash Reporter'


### PR DESCRIPTION
## Description

We don't need to install the `protobuf-c` package for build of PLCrashReporter.

## Related PRs or issues

https://github.com/microsoft/plcrashreporter/pull/303