### PR TITLE
Сopy PrivacyInfo to static xcframework

### DIFF
--- a/Scripts/combine-xcframework.sh
+++ b/Scripts/combine-xcframework.sh
@@ -26,4 +26,6 @@ xcodebuild -create-xcframework "${xcframeworksStatic[@]}" -output "${BUILT_PRODU
 # Copy the PrivacyInfo.xcprivacy file.
 echo "Copying new PrivacyInfo.xcprivacy to ${BUILT_PRODUCTS_DIR}/${PROJECT_NAME}.xcframework"
 cp ${SRCROOT}/Resources/PrivacyInfo.xcprivacy ${BUILT_PRODUCTS_DIR}/${PROJECT_NAME}.xcframework 
+cp ${SRCROOT}/Resources/PrivacyInfo.xcprivacy ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}-static.xcframework
+
 


### PR DESCRIPTION
We need this in the static xcframework because we use it to publish to CocoaPods.

[Build succeed.](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1522676&view=results)

## Related PRs or issues

[AB#104325](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/104325)
