### PR TITLE
Fix Xcode16 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PLCrashReporter Change Log
 
+# Version 1.11.3 (Under development)
+
+* **[Improvement]** Support Xcode 16 build.
+
+___
+
 ## Version 1.11.2
 
 * **[Improvement]** Update PLCrashReporter to include privacy manifest.

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -765,84 +765,6 @@
 		FCE45B4FD545A258E0292F25 /* PLCrashFrameStackUnwind.h in Headers */ = {isa = PBXBuildFile; fileRef = FCE4522F86AC61C08E9DCC17 /* PLCrashFrameStackUnwind.h */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXBuildRule section */
-		C2B72B1A24534DD200D03ABD /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.proxy.script;
-			filePatterns = "*.proto";
-			fileType = pattern.proxy;
-			inputFiles = (
-			);
-			isEditable = 1;
-			outputFiles = (
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.c",
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.h",
-			);
-			runOncePerArchitecture = 0;
-			script = "if type protoc-c > /dev/null; then\n  cd \"${INPUT_FILE_DIR}\" && protoc-c --c_out=. \"${INPUT_FILE_NAME}\"\nfi\n";
-		};
-		C2B72B2D24534F6200D03ABD /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.proxy.script;
-			filePatterns = "*.proto";
-			fileType = pattern.proxy;
-			inputFiles = (
-			);
-			isEditable = 1;
-			outputFiles = (
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.c",
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.h",
-			);
-			runOncePerArchitecture = 0;
-			script = "if type protoc-c > /dev/null; then\n  cd \"${INPUT_FILE_DIR}\" && protoc-c --c_out=. \"${INPUT_FILE_NAME}\"\nfi\n";
-		};
-		C2B72B2E24534F6800D03ABD /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.proxy.script;
-			filePatterns = "*.proto";
-			fileType = pattern.proxy;
-			inputFiles = (
-			);
-			isEditable = 1;
-			outputFiles = (
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.c",
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.h",
-			);
-			runOncePerArchitecture = 0;
-			script = "if type protoc-c > /dev/null; then\n  cd \"${INPUT_FILE_DIR}\" && protoc-c --c_out=. \"${INPUT_FILE_NAME}\"\nfi\n";
-		};
-		C2B72B2F24534F6B00D03ABD /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.proxy.script;
-			filePatterns = "*.proto";
-			fileType = pattern.proxy;
-			inputFiles = (
-			);
-			isEditable = 1;
-			outputFiles = (
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.c",
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.h",
-			);
-			runOncePerArchitecture = 0;
-			script = "if type protoc-c > /dev/null; then\n  cd \"${INPUT_FILE_DIR}\" && protoc-c --c_out=. \"${INPUT_FILE_NAME}\"\nfi\n";
-		};
-		C2B72B3024534F6F00D03ABD /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.proxy.script;
-			filePatterns = "*.proto";
-			fileType = pattern.proxy;
-			inputFiles = (
-			);
-			isEditable = 1;
-			outputFiles = (
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.c",
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.h",
-			);
-			runOncePerArchitecture = 0;
-			script = "if type protoc-c > /dev/null; then\n  cd \"${INPUT_FILE_DIR}\" && protoc-c --c_out=. \"${INPUT_FILE_NAME}\"\nfi\n";
-		};
-/* End PBXBuildRule section */
-
 /* Begin PBXContainerItemProxy section */
 		050DE25C0F61B92C00152ED3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2463,7 +2385,6 @@
 				05CD32660EE93DC3000FDE88 /* Frameworks */,
 			);
 			buildRules = (
-				C2B72B2E24534F6800D03ABD /* PBXBuildRule */,
 			);
 			dependencies = (
 				C26C52A52451B45D00D20162 /* PBXTargetDependency */,
@@ -2482,7 +2403,6 @@
 				05CD33220EE94439000FDE88 /* Frameworks */,
 			);
 			buildRules = (
-				C2B72B2F24534F6B00D03ABD /* PBXBuildRule */,
 			);
 			dependencies = (
 				054F50E90EEC50B30034B184 /* PBXTargetDependency */,
@@ -2518,7 +2438,6 @@
 				05E731F10EFA1AAB005EDFB7 /* Frameworks */,
 			);
 			buildRules = (
-				C2B72B1A24534DD200D03ABD /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
@@ -2576,7 +2495,6 @@
 				8064D8161C4D22D8005A8B4C /* Frameworks */,
 			);
 			buildRules = (
-				C2B72B2D24534F6200D03ABD /* PBXBuildRule */,
 			);
 			dependencies = (
 			);
@@ -2613,7 +2531,6 @@
 				8064D98F1C4D27E2005A8B4C /* Frameworks */,
 			);
 			buildRules = (
-				C2B72B3024534F6F00D03ABD /* PBXBuildRule */,
 			);
 			dependencies = (
 				80A63BC11C4D2BE20073B7A3 /* PBXTargetDependency */,

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -781,21 +781,6 @@
 			runOncePerArchitecture = 0;
 			script = "if type protoc-c > /dev/null; then\n  cd \"${INPUT_FILE_DIR}\" && protoc-c --c_out=. \"${INPUT_FILE_NAME}\"\nfi\n";
 		};
-		C2B72B2C24534F5C00D03ABD /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.proxy.script;
-			filePatterns = "*.proto";
-			fileType = pattern.proxy;
-			inputFiles = (
-			);
-			isEditable = 1;
-			outputFiles = (
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.c",
-				"${INPUT_FILE_DIR}/${INPUT_FILE_BASE}.pb-c.h",
-			);
-			runOncePerArchitecture = 0;
-			script = "if type protoc-c > /dev/null; then\n  cd \"${INPUT_FILE_DIR}\" && protoc-c --c_out=. \"${INPUT_FILE_NAME}\"\nfi\n";
-		};
 		C2B72B2D24534F6200D03ABD /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
@@ -2460,7 +2445,6 @@
 				05CD31500EE936A9000FDE88 /* Frameworks */,
 			);
 			buildRules = (
-				C2B72B2C24534F5C00D03ABD /* PBXBuildRule */,
 			);
 			dependencies = (
 			);

--- a/Dependencies/protobuf-c/generate-pb-c.sh
+++ b/Dependencies/protobuf-c/generate-pb-c.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cd "$(dirname "$0")/../../Source/" && protoc-c --c_out=. "PLCrashReport.proto"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ Also, next optional tools are used to build additional resources:
 
     to create binaries for all platforms.
 
+## Updating protobuf-c
+
+To update the `protobuf-c` dependency:
+
+1. Download the latest `protobuf-c.h` and `protobuf-c.c` files from the [protobuf-c GitHub repository](https://github.com/protobuf-c/protobuf-c).
+2. Replace the existing files in `Dependencies/protobuf-c` with the downloaded ones.
+3. Run the script:
+```bash
+./Dependencies/protobuf-c/generate-pb-c.sh
+```
+
 ## Contributing
 
 We are looking forward to your contributions via pull requests.


### PR DESCRIPTION

* [x] Has `CHANGELOG.md` been updated?
* [x] Are the files formatted correctly?
* [x] Did you test your change with the sample apps?

## Description

This PR fixes the Xcode 16 build crash by removing broken custom build phase.
Additionally, added  a script to generate `.pb-c` files replacing the removed build phase and updated the README with instructions on how to update the `protobuf-c` dependency.

## Related PRs or issues

#317 
[AB#107292](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/107292)
