### PR TITLE
Increase Xcode to 14.3.1 and macOS to 11.5

### DIFF
--- a/.azure-pipelines/analyze-and-test-1ES-template.yml
+++ b/.azure-pipelines/analyze-and-test-1ES-template.yml
@@ -7,7 +7,7 @@ jobs:
   - job: ''
     displayName: ${{ format('CrashReporter {0} Analyze and Test', platform) }}
     variables:
-      XCODE_PATH: '/Applications/Xcode_14.0.1.app/Contents/Developer'
+      XCODE_PATH: '/Applications/Xcode_14.3.1.app/Contents/Developer'
     templateContext:
       outputs:
       - output: pipelineArtifact

--- a/.azure-pipelines/analyze-and-test-template.yml
+++ b/.azure-pipelines/analyze-and-test-template.yml
@@ -9,7 +9,7 @@ jobs:
     pool:
       vmImage: macOS-12
     variables:
-      XCODE_PATH: '/Applications/Xcode_14.0.1.app/Contents/Developer'
+      XCODE_PATH: '/Applications/Xcode_14.3.1.app/Contents/Developer'
     steps:
     - checkout: self
       submodules: recursive

--- a/.azure-pipelines/build-plcrashreporter-1ES.yml
+++ b/.azure-pipelines/build-plcrashreporter-1ES.yml
@@ -6,7 +6,7 @@ pr:
 variables:
   Configuration: Release
   SDK: ''
-  XCODE_PATH: '/Applications/Xcode_13.2.1.app/Contents/Developer'
+  XCODE_PATH: '/Applications/Xcode_14.3.1.app/Contents/Developer'
 
 resources:
   repositories:
@@ -23,7 +23,7 @@ extends:
   parameters:
     pool:
       name: Azure Pipelines
-      image: macos-latest
+      image: macos-13
       os: macOS
     customBuildTags:
     - ES365AIMigrationTooling-BulkMigrated

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -4046,7 +4046,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Dependencies/protobuf-c\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LIBTOOLFLAGS = "-no_warning_for_no_symbols";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:identifier}";
@@ -4111,7 +4111,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Dependencies/protobuf-c\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				OTHER_LIBTOOLFLAGS = "-no_warning_for_no_symbols";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.${PRODUCT_NAME:identifier}";
 				PRODUCT_NAME = CrashReporter;

--- a/CrashReporter.xcodeproj/project.pbxproj
+++ b/CrashReporter.xcodeproj/project.pbxproj
@@ -3874,6 +3874,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				EFFECTIVE_PLATFORM_NAME = "-macosx";
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				PRODUCT_NAME = plcrashutil;
 				SDKROOT = macosx;
 			};
@@ -3884,6 +3885,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				EFFECTIVE_PLATFORM_NAME = "-macosx";
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				PRODUCT_NAME = plcrashutil;
 				SDKROOT = macosx;
 			};

--- a/Dependencies/protobuf.rb
+++ b/Dependencies/protobuf.rb
@@ -1,10 +1,9 @@
 class Protobuf < Formula
   desc "Protocol buffers (Google's data interchange format)"
   homepage "https://protobuf.dev/"
-  url "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protobuf-25.3.tar.gz"
-  sha256 "d19643d265b978383352b3143f04c0641eea75a75235c111cc01a1350173180e"
+  url "https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz"
+  sha256 "7c3ebd7aaedd86fa5dc479a0fda803f602caaf78d8aff7ce83b89e1b8ae7442a"
   license "BSD-3-Clause"
-  revision 1
 
   livecheck do
     url :stable
@@ -12,39 +11,39 @@ class Protobuf < Formula
   end
 
   bottle do
-    sha256                               arm64_sonoma:   "fddad1ce30679b586263d42f6873ad14033bf081f1a02265a2dfd0db6c5b90a9"
-    sha256                               arm64_ventura:  "e5f9660c2add8a0b25a739d8733f8e39994627a52c4280fda3f6a6952fd3580c"
-    sha256                               arm64_monterey: "25697e79cbf8a2aa5ae3c70e2a03700cd8c071a1731ecc3eb89bcf44e7d70310"
-    sha256                               sonoma:         "f39583032815a31f5d31b520e24d70f75755e921235496b29fd1ed964fd6bcb5"
-    sha256                               ventura:        "7a1992bf50282507f8a5b707b98f85d02cc95da61b4a77145ecaa7dc48905f5f"
-    sha256                               monterey:       "80f58bba003e5b796d80d00a9324326431340a44abcbcf722596db9c95fc7055"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "56699682719d48c950eb9e0e862669759e974d9120b08b3d004a61fdd4b4bae8"
+    sha256 cellar: :any,                 arm64_sequoia: "cec9ebadfa0ff65482e3e195660a13ca43844792ed98822ad10b2bca4ef8e45c"
+    sha256 cellar: :any,                 arm64_sonoma:  "537ab66678b04aa2e770bc65aa710d63f37a1b5a1c65717c2e8954cdbb94d883"
+    sha256 cellar: :any,                 arm64_ventura: "4a0a0e6db20bd8444491b35c34d6c51e42b493bcb3a3e6b309bdbd06bd85eab9"
+    sha256 cellar: :any,                 sonoma:        "446d7adcff7604c570a50f2aca5484612a32481cbe677e1bccdbe62989062de4"
+    sha256 cellar: :any,                 ventura:       "e52757d69a1f986314de2dd508eae336a544fb96838038fb76d0915b017bcc32"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b62500bd2fcf54e820720441d969bca0204ce95bab6e16dcb247bb28398356bd"
   end
 
   depends_on "cmake" => :build
-  depends_on "python-setuptools" => :build
-  depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.12" => [:build, :test]
   depends_on "abseil"
-  depends_on "jsoncpp"
-
   uses_from_macos "zlib"
 
-  def pythons
-    deps.map(&:to_formula)
-        .select { |f| f.name.match?(/^python@\d\.\d+$/) }
-        .map { |f| f.opt_libexec/"bin/python" }
+  on_macos do
+    # We currently only run tests on macOS.
+    # Running them on Linux requires rebuilding googletest with `-fPIC`.
+    depends_on "googletest" => :build
+  end
+
+  patch do
+    url "https://github.com/protocolbuffers/protobuf/commit/e490bff517916495ed3a900aa85791be01f674f5.patch?full_index=1"
+    sha256 "7e89d0c379d89b24cb6fe795cd9d68e72f0b83fcc95dd91af721d670ad466022"
   end
 
   def install
     # Keep `CMAKE_CXX_STANDARD` in sync with the same variable in `abseil.rb`.
     abseil_cxx_standard = 17
-    cmake_args = %w[
+    cmake_args = %W[
       -DBUILD_SHARED_LIBS=ON
       -Dprotobuf_BUILD_LIBPROTOC=ON
       -Dprotobuf_BUILD_SHARED_LIBS=ON
       -Dprotobuf_INSTALL_EXAMPLES=ON
-      -Dprotobuf_BUILD_TESTS=OFF
+      -Dprotobuf_BUILD_TESTS=#{OS.mac? ? "ON" : "OFF"}
+      -Dprotobuf_USE_EXTERNAL_GTEST=ON
       -Dprotobuf_ABSL_PROVIDER=package
       -Dprotobuf_JSONCPP_PROVIDER=package
     ]
@@ -52,27 +51,11 @@ class Protobuf < Formula
 
     system "cmake", "-S", ".", "-B", "build", *cmake_args, *std_cmake_args
     system "cmake", "--build", "build"
+    system "ctest", "--test-dir", "build", "--verbose" if OS.mac?
     system "cmake", "--install", "build"
 
     (share/"vim/vimfiles/syntax").install "editors/proto.vim"
     elisp.install "editors/protobuf-mode.el"
-
-    ENV.append_to_cflags "-I#{include}"
-    ENV.append_to_cflags "-L#{lib}"
-    ENV["PROTOC"] = bin/"protoc"
-
-    cd "python" do
-      # Keep C++ standard in sync with `abseil.rb`.
-      inreplace "setup.py", "extra_compile_args.append('-std=c++14')",
-                            "extra_compile_args.append('-std=c++#{abseil_cxx_standard}')"
-
-      pythons.each do |python|
-        pyext_dir = prefix/Language::Python.site_packages(python)/"google/protobuf/pyext"
-        with_env(LDFLAGS: "-Wl,-rpath,#{rpath(source: pyext_dir)} #{ENV.ldflags}".strip) do
-          system python, *Language::Python.setup_install_args(prefix, python), "--cpp_implementation"
-        end
-      end
-    end
   end
 
   test do
@@ -88,9 +71,5 @@ class Protobuf < Formula
     EOS
     (testpath/"test.proto").write testdata
     system bin/"protoc", "test.proto", "--cpp_out=."
-
-    pythons.each do |python|
-      system python, "-c", "from google.protobuf.pyext import _message"
-    end
   end
 end

--- a/Other Sources/plcrashutil/main.m
+++ b/Other Sources/plcrashutil/main.m
@@ -36,7 +36,7 @@
 /*
  * Print command line usage.
  */
-static void print_usage () {
+static void print_usage (void) {
     fprintf(stderr, "Usage: plcrashutil <command> <options>\n"
                     "Commands:\n"
                     "  convert --format=<format> <file>\n"

--- a/PLCrashReporter.podspec
+++ b/PLCrashReporter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
   spec.resource_bundle = { 'PLCrashReporter' => 'CrashReporter.xcframework/PrivacyInfo.xcprivacy' }
 
   spec.ios.deployment_target    = '11.0'
-  spec.osx.deployment_target    = '10.9'
+  spec.osx.deployment_target    = '11.5'
   spec.tvos.deployment_target   = '11.0'
   spec.vendored_frameworks = "CrashReporter.xcframework"
 end

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The easiest way to use PLCrashReporter is by using [AppCenter](https://appcenter
 ## Prerequisites
 
 - Xcode 11 or above.
-- Minimum supported platforms: iOS 11, macOS 10.9, tvOS 11, Mac Catalyst 13.0.
+- Minimum supported platforms: iOS 11, macOS 11.5, tvOS 11, Mac Catalyst 13.0.
 
 ## Decoding Crash Reports
 


### PR DESCRIPTION
## Description

This PR increases minimum supported versions of Xcode to 14.3.1 and macOS to 11.5.
Additionally, it updates protobuf.rb script.

## Related PRs or issues

[AB#108119](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/108119)
[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1549464&view=results)

