### PR TITLE
Exclude shellscript from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
                 "Source/PLCrashAsyncLinkedList.hpp",
                 "Source/PLCrashReport.proto",
                 "Tools/CrashViewer/",	
-                "Other Sources/Crash Demo/"
+                "Other Sources/Crash Demo/",
+                "Dependencies/protobuf-c/generate-pb-c.sh",
             ],
             sources: [
                 "Source",


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with the sample apps?

## Description
Excluded generate-pb-c.sh shellscript from package.swift in order to successfully compile crashreporter. Tested out compilation with [swift-6.1-DEVELOPMENT-SNAPSHOT-2024-12-04-a](https://download.swift.org/swift-6.1-branch/xcode/swift-6.1-DEVELOPMENT-SNAPSHOT-2024-12-04-a/swift-6.1-DEVELOPMENT-SNAPSHOT-2024-12-04-a-osx.pkg) as changes from https://github.com/swiftlang/swift-package-manager/pull/7962 aren't officially released.

[Build succeeded
](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1550535&view=results)
## Related PRs or issues
[#107565](https://dev.azure.com/msmobilecenter/Mobile-Center/_boards/board/t/Mobile%20SDK%20team/Backlog%20Items?System.AssignedTo=v-djordjed%40microsoft.com&workitem=107565)
https://github.com/microsoft/plcrashreporter/issues/315
