### PR TITLE
fix endless loop on crash after init during +load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **[Improvement]** Update target iOS and tvOS version to 12.0.
 * **[Improvement]** Support Xcode 16 build.
+* **[Fix]** Fix endless loop when PLCrashReporter was set up during `load`.
 
 ___
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with the sample apps?

## Description
This PR fixes an issue in the PLCrashReporter, where a static initialization of units (in the +load method), could lead to an endless loop when trying to handle a crash.
This happens because the crash callback handlers are set even though the static shared_handler_context is not initialized yet. Once the shared_handler_context gets initialized, the list of callbacks initialized as empty. This leads to an endless loop, as no callback to handle a crash is available.
The underlying issue is connected to the (Static Initialization Order Fiasco)[[https://en.cppreference.com/w/cpp/language/siof],](https://en.cppreference.com/w/cpp/language/siof%5D,) due to initialization of static objects from different translation units when one depends on the other being initialized already.

## Solution
We need to force the static struct (shared_handler_context) to be initialized on first access. This PR achieves this by adapting the shared_handler_context to be used as a function and adapts its usage throughout the PLCrashSignalHandler. Using this approach, we can centralize the initialization and enforce a proper order, resolving the underlaying issue.

## Related PRs or issues
https://github.com/microsoft/plcrashreporter/issues/325

## Misc
All tests are running through, except `testStackWalkerRegression`, but this one also fails for me locally on master.
Not sure how to properly unit test this since it's pretty hard to reproduce and needs another app to load it during it's load.
