### PR TITLE
Do not include trailing zero byte in process_path

### DIFF
--- a/Source/PLCrashLogWriter.m
+++ b/Source/PLCrashLogWriter.m
@@ -359,7 +359,7 @@ plcrash_error_t plcrash_log_writer_init (plcrash_log_writer_t *writer,
                 char *process_path = malloc(process_path_len);
                 _NSGetExecutablePath(process_path, &process_path_len);
                 writer->process_info.process_path.data = process_path;
-                writer->process_info.process_path.len = process_path_len;
+                writer->process_info.process_path.len = strnlen(process_path, process_path_len);
             }
         }
 


### PR DESCRIPTION
process_path_len contains the required buffer size which includes a terminating zero byte. This zero byte is only necessary for C strings. It should not be part of the data that is encoded in the crash report.

Compare to process_name, which is encoded correctly without trailing zero byte.

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers! -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with the sample apps?

## Description

Remove the trailing zero byte in the process_info.process_path field

## Related PRs or issues

no related issues

## Misc

This causes problems when importing crash reports into PostgreSQL, which raises an error when a string contains a zero byte. In some languages, the trailing zero is silently ignored (eg. when using strlen / strdup in C, or when using some NSString or String initializers in Objective C or Swift)
